### PR TITLE
Shift the time dependency to a "stats" feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: rust
 script:
   - (cd phf && cargo test)
+  - (cd phf_mac && cargo test --features stats)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Rust-PHF is a library to generate efficient lookup tables at compile time using
 
 It currently uses the
 [CHD algorithm](http://cmph.sourceforge.net/papers/esa09.pdf) and can generate
-a 100,000 entry map in roughly .4 seconds.
+a 100,000 entry map in roughly .4 seconds. By default statistics are not
+produced, but if you use the `phf_mac` crate with the `stats` feature enabled
+(writing `phf_mac/stats` in the `[dependencies]` section of your `Cargo.toml`
+instead of `phf_mac`) and set the environment variable `PHF_STATS` it will
+issue a compiler note about how long it took.
 
 Documentation is available at https://sfackler.github.io/doc/phf
 

--- a/phf_mac/Cargo.toml
+++ b/phf_mac/Cargo.toml
@@ -12,9 +12,13 @@ path = "src/lib.rs"
 plugin = true
 test = false
 
+[features]
+stats = ["time"]
+
 [dependencies.phf_shared]
 path = "../phf_shared"
 version = "=0.4.8"
 
-[dependencies]
-time = "0.1"
+[dependencies.time]
+version = "0.1"
+optional = true

--- a/phf_mac/src/lib.rs
+++ b/phf_mac/src/lib.rs
@@ -7,6 +7,7 @@
 
 extern crate rand;
 extern crate syntax;
+#[cfg(feature = "stats")]
 extern crate time;
 extern crate rustc;
 extern crate phf_shared;


### PR DESCRIPTION
This makes it optional, which is kinda convenient when time won’t build
because gcc is behind the times. But more importantly, it’ll be just a
tad faster.

(I’ll admit I did it purely because gcc wasn’t building at the time, but I still think it’s a good idea.)