### PR TITLE
Add `index` methods to `OrderedMap` and `OrderedSet`.

### DIFF
--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -81,6 +81,12 @@ impl<K, V> OrderedMap<K, V> {
         self.get_internal(key).map(|(i, _)| i)
     }
 
+    /// Returns references to both the key and values at an index
+    /// within the list used to initialize the ordered map. See `.get_index(key)`.
+    pub fn index(&self, index: usize) -> Option<(&K, &V)> {
+        self.entries.get(index).map(|&(ref k, ref v)| (k, v))
+    }
+
     /// Like `get`, but returns both the key and the value.
     pub fn get_entry<T: ?Sized>(&self, key: &T) -> Option<(&K, &V)>
             where T: Eq + PhfHash, K: Borrow<T> {

--- a/phf/src/ordered_set.rs
+++ b/phf/src/ordered_set.rs
@@ -54,6 +54,12 @@ impl<T> OrderedSet<T> {
         self.map.get_index(key)
     }
 
+    /// Returns references to both the key and values at an index
+    /// within the list used to initialize the ordered map. See `.get_index(key)`.
+    pub fn index(&self, index: usize) -> Option<&T> {
+        self.map.index(index).map(|(k, &())| k)
+    }
+
     /// Returns true if `value` is in the `Set`.
     pub fn contains<U: ?Sized>(&self, value: &U) -> bool where U: Eq + PhfHash, T: Borrow<U> {
         self.map.contains_key(value)


### PR DESCRIPTION
This replaces the `RandomAccessIterator` impls removed in e2152739cbdd471116d88bb4a9cea4cdfede1e42.

See https://github.com/servo/string-cache/issues/80