### PR TITLE
Remove prelude imports

### DIFF
--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -1,6 +1,5 @@
 //! An immutable map constructed at compile time.
 use debug_builders::DebugMap;
-use std::prelude::v1::*;
 use std::borrow::Borrow;
 use std::ops::Index;
 use std::slice;

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -1,6 +1,5 @@
 //! An order-preserving immutable map constructed at compile time.
 use debug_builders::DebugMap;
-use std::prelude::v1::*;
 use std::borrow::Borrow;
 use std::iter::IntoIterator;
 use std::ops::Index;

--- a/phf/src/ordered_set.rs
+++ b/phf/src/ordered_set.rs
@@ -1,6 +1,5 @@
 //! An order-preserving immutable set constructed at compile time.
 use debug_builders::DebugSet;
-use std::prelude::v1::*;
 use std::borrow::Borrow;
 use std::iter::IntoIterator;
 use std::fmt;

--- a/phf/src/set.rs
+++ b/phf/src/set.rs
@@ -1,6 +1,5 @@
 //! An immutable set constructed at compile time.
 use debug_builders::DebugSet;
-use std::prelude::v1::*;
 use std::borrow::Borrow;
 use std::iter::IntoIterator;
 use std::fmt;


### PR DESCRIPTION
They cause conflicts with IntoIterator imports, and by removing the prelude
import instead of IntoIterator this enables continuing to work with 1.0.0-beta