### PR TITLE
Don’t use/recommend `env!` in build scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,13 @@ build.rs
 ```rust
 extern crate phf_codegen;
 
+use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
 fn main() {
-    let path = Path::new(env!("OUT_DIR")).join("codegen.rs");
+    let path = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");
     let mut file = BufWriter::new(File::create(&path).unwrap());
 
     write!(&mut file, "static KEYWORDS: phf::Map<&'static str, Keyword> = ").unwrap();

--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -12,12 +12,13 @@
 //! ```rust,no_run
 //! extern crate phf_codegen;
 //!
+//! use std::env;
 //! use std::fs::File;
 //! use std::io::{BufWriter, Write};
 //! use std::path::Path;
 //!
 //! fn main() {
-//!     let path = Path::new(env!("OUT_DIR")).join("codegen.rs");
+//!     let path = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");
 //!     let mut file = BufWriter::new(File::create(&path).unwrap());
 //!
 //!     write!(&mut file, "static KEYWORDS: phf::Map<&'static str, Keyword> = ").unwrap();

--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -1,11 +1,12 @@
 extern crate phf_codegen;
 
+use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
 fn main() {
-    let file = Path::new(env!("OUT_DIR")).join("codegen.rs");
+    let file = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");
     let mut file = BufWriter::new(File::create(&file).unwrap());
 
     write!(&mut file, "static MAP: ::phf::Map<u32, &'static str> = ").unwrap();


### PR DESCRIPTION
It does the wrong thing when cross-compiling: https://github.com/servo/servo/pull/6850#issuecomment-126409322