### PR TITLE
Add hash() and get_index() to phf_shared.

### DIFF
--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -2,7 +2,6 @@
 use debug_builders::DebugMap;
 use std::borrow::Borrow;
 use std::ops::Index;
-use std::hash::{Hasher, SipHasher};
 use std::slice;
 use std::fmt;
 use std::iter::IntoIterator;
@@ -71,13 +70,9 @@ impl<K, V> Map<K, V> {
     /// Like `get`, but returns both the key and the value.
     pub fn get_entry<T: ?Sized>(&self, key: &T) -> Option<(&K, &V)>
             where T: Eq + PhfHash, K: Borrow<T> {
-        let mut hasher = SipHasher::new_with_keys(0, self.key);
-        key.phf_hash(&mut hasher);
-        let (g, f1, f2) = phf_shared::split(hasher.finish());
-
-        let (d1, d2) = self.disps[(g % (self.disps.len() as u32)) as usize];
-        let entry = &self.entries[(phf_shared::displace(f1, f2, d1, d2) % (self.entries.len() as u32))
-                                  as usize];
+        let hash = phf_shared::hash(key, self.key);
+        let index = phf_shared::get_index(hash, self.disps, self.entries.len());
+        let entry = &self.entries[index as usize];
         let b: &T = entry.0.borrow();
         if b == key {
             Some((&entry.0, &entry.1))

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -1,7 +1,6 @@
 //! An order-preserving immutable map constructed at compile time.
 use debug_builders::DebugMap;
 use std::borrow::Borrow;
-use std::hash::{Hasher, SipHasher};
 use std::iter::IntoIterator;
 use std::ops::Index;
 use std::fmt;
@@ -95,12 +94,9 @@ impl<K, V> OrderedMap<K, V> {
 
     fn get_internal<T: ?Sized>(&self, key: &T) -> Option<(usize, (&K, &V))>
             where T: Eq + PhfHash, K: Borrow<T> {
-        let mut hasher = SipHasher::new_with_keys(0, self.key);
-        key.phf_hash(&mut hasher);
-        let (g, f1, f2) = phf_shared::split(hasher.finish());
-
-        let (d1, d2) = self.disps[(g % (self.disps.len() as u32)) as usize];
-        let idx = self.idxs[(phf_shared::displace(f1, f2, d1, d2) % (self.idxs.len() as u32)) as usize];
+        let hash = phf_shared::hash(key, self.key);
+        let idx_index = phf_shared::get_index(hash, self.disps, self.idxs.len());
+        let idx = self.idxs[idx_index as usize];
         let entry = &self.entries[idx];
 
         let b: &T = entry.0.borrow();

--- a/phf_generator/src/lib.rs
+++ b/phf_generator/src/lib.rs
@@ -4,7 +4,6 @@ extern crate rand;
 
 use phf_shared::PhfHash;
 use rand::{SeedableRng, XorShiftRng, Rng};
-use std::hash::{Hasher, SipHasher};
 
 const DEFAULT_LAMBDA: usize = 5;
 
@@ -38,12 +37,10 @@ fn try_generate_hash<H: PhfHash>(entries: &[H], rng: &mut XorShiftRng) -> Option
     }
 
     let key = rng.gen();
-    let hasher = SipHasher::new_with_keys(0, key);
 
     let hashes: Vec<_> = entries.iter().map(|entry| {
-        let mut hasher = hasher.clone();
-        entry.phf_hash(&mut hasher);
-        let (g, f1, f2) = phf_shared::split(hasher.finish());
+        let hash = phf_shared::hash(entry, key);
+        let (g, f1, f2) = phf_shared::split(hash);
         Hashes {
             g: g,
             f1: f1,


### PR DESCRIPTION
In https://github.com/servo/string-cache, we currently use a `phf::OrderedSet` with its `get_index` method to get an identified stored in an `Atom`, and `index` to get a string back from that identifier.

However, the extra inderection of `OrderedSet` of `Set` is not necessary. We don’t care about the order, only about getting numeric identifiers.

Additionally, when `get_index` returns `None`, we hash the input string again to find it in table of dynamic atoms. With this chang, we can reuse the phf hash instead: https://github.com/servo/string-cache/pull/103

At first I tried adding hash and index access to `phf::Map`, but the API got messy quickly. Do you think that is worth pursuing more, rather than having string-cache use phf internals?