### PR TITLE
Add phf_match! macro

### DIFF
--- a/phf_macros/src/macros.rs
+++ b/phf_macros/src/macros.rs
@@ -85,3 +85,26 @@ macro_rules! phf_ordered_map {
 macro_rules! phf_ordered_set {
     ($($entry:expr),*) => {/* ... */}
 }
+
+/// Constructs a match expression that uses PHF to index into the match arms.
+///
+/// # Examples
+///
+/// ```rust
+/// #![feature(plugin)]
+/// #![plugin(phf_macros)]
+///
+/// extern crate phf;
+/// extern crate phf_shared;
+///
+/// fn lookup(key: &str) -> String {
+///     phf_match!(key,
+///         "hello" => String::from("first"),
+///         "world" => String::from("second"),
+///         _ => String::from("rest"),
+///     )
+/// }
+/// ```
+macro_rules! phf_match {
+    ($expr:expr, $($key:expr => $value:expr,)*) => {/* ... */}
+}

--- a/phf_macros/tests/test.rs
+++ b/phf_macros/tests/test.rs
@@ -2,6 +2,7 @@
 #![plugin(phf_macros)]
 
 extern crate phf;
+extern crate phf_shared;
 
 mod map {
     use std::collections::{HashMap, HashSet};
@@ -493,5 +494,38 @@ mod ordered_set {
         for e in &SET {
             assert_eq!(&"foo", e);
         }
+    }
+}
+
+mod match_ {
+    #[test]
+    fn test_zero() {
+        assert_eq!(phf_match!("foo" { _ => 0 }), 0);
+        assert_eq!(phf_match!("bar" { _ => 0 }), 0);
+
+        assert_eq!(phf_match!("foo" { _ => 0, }), 0);
+        assert_eq!(phf_match!("foo" { _ => { 0 } }), 0);
+        assert_eq!(phf_match!("foo" { _ => { 0 }, }), 0);
+    }
+
+    #[test]
+    fn test_one() {
+        assert_eq!(phf_match!("foo" { "foo" => 0, _ => 1 }), 0);
+        assert_eq!(phf_match!("bar" { "foo" => 0, _ => 1 }), 1);
+    }
+
+    #[test]
+    fn test_two() {
+        assert_eq!(phf_match!("foo" { "foo" => 0, "bar" => 1, _ => 2 }), 0);
+        assert_eq!(phf_match!("bar" { "foo" => 0, "bar" => 1, _ => 2 }), 1);
+        assert_eq!(phf_match!("baz" { "foo" => 0, "bar" => 1, _ => 2 }), 2);
+    }
+
+    #[test]
+    fn test_three() {
+        assert_eq!(phf_match!("foo" { "foo" => 0, "bar" => 1, "baz" => 2, _ => 3 }), 0);
+        assert_eq!(phf_match!("bar" { "foo" => 0, "bar" => 1, "baz" => 2, _ => 3 }), 1);
+        assert_eq!(phf_match!("baz" { "foo" => 0, "bar" => 1, "baz" => 2, _ => 3 }), 2);
+        assert_eq!(phf_match!("boo" { "foo" => 0, "bar" => 1, "baz" => 2, _ => 3 }), 3);
     }
 }


### PR DESCRIPTION
This macro performs slightly faster than the full map macro since there may be some better opportunities for inlining than phf::Map.

```
test map::bench_phf_match_none ... bench:         724 ns/iter (+/- 282)
test map::bench_phf_match_some ... bench:         791 ns/iter (+/- 444)
test map::bench_phf_none       ... bench:         757 ns/iter (+/- 158)
test map::bench_phf_some       ... bench:         938 ns/iter (+/- 289)
```