### PR TITLE
Registry now seems to live in rustc_plugin instead of rustc::plugin

### DIFF
--- a/phf_macros/src/lib.rs
+++ b/phf_macros/src/lib.rs
@@ -36,7 +36,7 @@
 extern crate syntax;
 #[cfg(feature = "stats")]
 extern crate time;
-extern crate rustc;
+extern crate rustc_plugin;
 extern crate phf_shared;
 extern crate phf_generator;
 
@@ -49,7 +49,7 @@ use syntax::fold::Folder;
 use syntax::parse;
 use syntax::parse::token::{InternedString, Comma, Eof, FatArrow};
 use syntax::print::pprust;
-use rustc::plugin::Registry;
+use rustc_plugin::Registry;
 use phf_generator::HashState;
 use std::env;
 


### PR DESCRIPTION
Without this change I get:

```
/Users/david/.cargo/registry/src/github.com-88ac128001ac3a9a/phf_macros-0.7.8/src/lib.rs:52:5: 52:28 error: unresolved import `rustc::plugin::Registry`. Could not find `plugin` in `rustc` [E0432]
/Users/david/.cargo/registry/src/github.com-88ac128001ac3a9a/phf_macros-0.7.8/src/lib.rs:52 use rustc::plugin::Registry;
```

With it, everything seems to work.