### PR TITLE
Support byte string keys in phf_macros (fixes #76)

### DIFF
--- a/phf_macros/tests/test.rs
+++ b/phf_macros/tests/test.rs
@@ -17,6 +17,11 @@ mod map {
         "foo" => 10
     );
 
+    #[allow(dead_code)]
+    static BYTE_STRING_KEY: phf::Map<&'static [u8], &'static str> = phf_map!(
+        b"camembert" => "delicious",
+    );
+
     #[test]
     fn test_two() {
         static MAP: phf::Map<&'static str, isize> = phf_map!(


### PR DESCRIPTION
Because of https://github.com/rust-lang/rust/issues/31260, a cast must be inserted explicitly instead of letting rustc implicitly coercing the type.