### PR TITLE
Allow specifying a module path to the phf crate for codegen

### DIFF
--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -93,6 +93,7 @@ use std::io::prelude::*;
 pub struct Map<K> {
     keys: Vec<K>,
     values: Vec<String>,
+    path: String,
 }
 
 impl<K: Hash+PhfHash+Eq+fmt::Debug> Map<K> {
@@ -112,7 +113,14 @@ impl<K: Hash+PhfHash+Eq+fmt::Debug> Map<K> {
         Map {
             keys: vec![],
             values: vec![],
+            path: String::from("::phf"),
         }
+    }
+
+    /// Set the path to the `phf` crate from the global namespace
+    pub fn phf_path(&mut self, path: &str) -> &mut Map<K> {
+        self.path = path.to_owned();
+        self
     }
 
     /// Adds an entry to the builder.
@@ -120,7 +128,7 @@ impl<K: Hash+PhfHash+Eq+fmt::Debug> Map<K> {
     /// `value` will be written exactly as provided in the constructed source.
     pub fn entry(&mut self, key: K, value: &str) -> &mut Map<K> {
         self.keys.push(key);
-        self.values.push(value.to_string());
+        self.values.push(value.to_owned());
         self
     }
 
@@ -140,10 +148,10 @@ impl<K: Hash+PhfHash+Eq+fmt::Debug> Map<K> {
         let state = phf_generator::generate_hash(&self.keys);
 
         try!(write!(w,
-                    "::phf::Map {{
+                    "{}::Map {{
     key: {},
-    disps: ::phf::Slice::Static(&[",
-                    state.key));
+    disps: {}::Slice::Static(&[",
+                    self.path, state.key, self.path));
         for &(d1, d2) in &state.disps {
             try!(write!(w,
                         "
@@ -177,7 +185,15 @@ pub struct Set<T> {
 impl<T: Hash+PhfHash+Eq+fmt::Debug> Set<T> {
     /// Constructs a new `phf::Set` builder.
     pub fn new() -> Set<T> {
-        Set { map: Map::new() }
+        Set {
+            map: Map::new(),
+        }
+    }
+
+    /// Set the path to the `phf` crate from the global namespace
+    pub fn phf_path(&mut self, path: &str) -> &mut Set<T> {
+        self.map.phf_path(path);
+        self
     }
 
     /// Adds an entry to the builder.
@@ -192,7 +208,7 @@ impl<T: Hash+PhfHash+Eq+fmt::Debug> Set<T> {
     ///
     /// Panics if there are any duplicate entries.
     pub fn build<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        try!(write!(w, "::phf::Set {{ map: "));
+        try!(write!(w, "{}::Set {{ map: ", self.map.path));
         try!(self.map.build(w));
         write!(w, " }}")
     }
@@ -202,6 +218,7 @@ impl<T: Hash+PhfHash+Eq+fmt::Debug> Set<T> {
 pub struct OrderedMap<K> {
     keys: Vec<K>,
     values: Vec<String>,
+    path: String,
 }
 
 impl<K: Hash+PhfHash+Eq+fmt::Debug> OrderedMap<K> {
@@ -210,7 +227,14 @@ impl<K: Hash+PhfHash+Eq+fmt::Debug> OrderedMap<K> {
         OrderedMap {
             keys: vec![],
             values: vec![],
+            path: String::from("::phf"),
         }
+    }
+
+    /// Set the path to the `phf` crate from the global namespace
+    pub fn phf_path(&mut self, path: &str) -> &mut OrderedMap<K> {
+        self.path = path.to_owned();
+        self
     }
 
     /// Adds an entry to the builder.
@@ -218,7 +242,7 @@ impl<K: Hash+PhfHash+Eq+fmt::Debug> OrderedMap<K> {
     /// `value` will be written exactly as provided in the constructed source.
     pub fn entry(&mut self, key: K, value: &str) -> &mut OrderedMap<K> {
         self.keys.push(key);
-        self.values.push(value.to_string());
+        self.values.push(value.to_owned());
         self
     }
 
@@ -239,10 +263,10 @@ impl<K: Hash+PhfHash+Eq+fmt::Debug> OrderedMap<K> {
         let state = phf_generator::generate_hash(&self.keys);
 
         try!(write!(w,
-                    "::phf::OrderedMap {{
+                    "{}::OrderedMap {{
     key: {},
-    disps: ::phf::Slice::Static(&[",
-                    state.key));
+    disps: {}::Slice::Static(&[",
+                    self.path, state.key, self.path));
         for &(d1, d2) in &state.disps {
             try!(write!(w,
                         "
@@ -286,7 +310,15 @@ pub struct OrderedSet<T> {
 impl<T: Hash+PhfHash+Eq+fmt::Debug> OrderedSet<T> {
     /// Constructs a new `phf::OrderedSet` builder.
     pub fn new() -> OrderedSet<T> {
-        OrderedSet { map: OrderedMap::new() }
+        OrderedSet {
+            map: OrderedMap::new(),
+        }
+    }
+
+    /// Set the path to the `phf` crate from the global namespace
+    pub fn phf_path(&mut self, path: &str) -> &mut OrderedSet<T> {
+        self.map.phf_path(path);
+        self
     }
 
     /// Adds an entry to the builder.
@@ -302,7 +334,7 @@ impl<T: Hash+PhfHash+Eq+fmt::Debug> OrderedSet<T> {
     ///
     /// Panics if there are any duplicate entries.
     pub fn build<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        try!(write!(w, "::phf::OrderedSet {{ map: "));
+        try!(write!(w, "{}::OrderedSet {{ map: ", self.map.path));
         try!(self.map.build(w));
         write!(w, " }}")
     }


### PR DESCRIPTION
At the most basic level, this means you can use `phf_codegen` if you've got something like `extern crate phf as __some_phf_alias;`. More usefully, this PR permits crates to add their own codegen on top of `phf` without requiring all consuming crates to explicitly depend on `phf`.

Concretely, I want this for https://github.com/servo/string-cache/pull/136. See https://github.com/servo/string-cache/pull/136/files#diff-f5597aa77bf5eea303399f7125c5a0adR10 and the current hack I'm resorting to at https://github.com/servo/string-cache/pull/136/files#diff-141f99248469f8dc2a1daf108bbf23c1R71 (relies on the next string being written to start with `::phf`).

To briefly explain the problem: it's a given that consumers of `string_cache_codegen` will need to depend on `string_cache`. However, if `string_cache_codegen` generates a vanilla phf map, consumers of `string_cache_codegen` also need to add `phf` to their own Cargo.toml and add `extern crate phf;`. Exposing `phf` under the `string_cache` crate sidesteps this inconvenience by using the existing `string_cache` dependency (and means you don't have to upgrade `string_cache` and `phf` in lockstep).

(I'm open to suggestions for better ways to do this by the way)