### PR TITLE
Update the TokenTree import

### DIFF
--- a/phf_macros/src/lib.rs
+++ b/phf_macros/src/lib.rs
@@ -42,7 +42,8 @@ extern crate phf_generator;
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use syntax::ast::{self, Expr, ExprKind, Mutability, TokenTree, TyKind};
+use syntax::ast::{self, Expr, ExprKind, Mutability, TyKind};
+use syntax::tokenstream::TokenTree;
 use syntax::codemap::Span;
 use syntax::ext::base::{DummyResult, ExtCtxt, MacResult};
 use syntax::ext::build::AstBuilder;


### PR DESCRIPTION
In order to make the phf_macros library build on newer versions of Rust.