### PR TITLE
Add UniCase support to phf_macros and bump unicase version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rust:
 - 1.6.0
 script:
 - (test $TRAVIS_RUST_VERSION != "nightly" || (cd phf_macros && cargo test))
+- (test $TRAVIS_RUST_VERSION != "nightly" || (cd phf_macros && cargo test --features unicase_support))
 - (test $TRAVIS_RUST_VERSION != "nightly" || (cd phf_macros && cargo test --features stats))
 - (test $TRAVIS_RUST_VERSION != "nightly" || (cd phf_macros && cargo bench))
 - (test $TRAVIS_RUST_VERSION != "nightly" || (cd phf_shared && cargo build --features core))

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -36,3 +36,6 @@ optional = true
 [dev-dependencies.phf]
 path = "../phf"
 version = "=0.7.16"
+
+[dev-dependencies.compiletest_rs]
+version = "0.2"

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -15,6 +15,7 @@ test = false
 
 [features]
 stats = ["time"]
+unicase_support = ["unicase", "phf_shared/unicase"]
 
 [dependencies.phf_generator]
 path = "../phf_generator"
@@ -26,6 +27,10 @@ version = "=0.7.16"
 
 [dependencies.time]
 version = "0.1"
+optional = true
+
+[dependencies.unicase]
+version = "1.4"
 optional = true
 
 [dev-dependencies.phf]

--- a/phf_macros/src/lib.rs
+++ b/phf_macros/src/lib.rs
@@ -39,6 +39,8 @@ extern crate time;
 extern crate rustc_plugin;
 extern crate phf_shared;
 extern crate phf_generator;
+#[cfg(feature = "unicase_support")]
+extern crate unicase;
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
@@ -55,6 +57,8 @@ use syntax::ptr::P;
 use rustc_plugin::Registry;
 use phf_generator::HashState;
 use std::env;
+#[cfg(feature = "unicase_support")]
+use unicase::UniCase;
 
 use util::{Entry, Key};
 use util::{create_map, create_set, create_ordered_map, create_ordered_set};
@@ -282,8 +286,30 @@ fn parse_key(cx: &mut ExtCtxt, e: &Expr) -> Option<Key> {
                 None
             }
         }
+        #[cfg(feature = "unicase_support")]
+        ExprKind::Call(ref f, ref args) => {
+            if let ExprKind::Path(_, ref path) = f.node {
+                if path.segments.last().unwrap().identifier.name.as_str() == "UniCase" {
+                    if args.len() == 1 {
+                        if let ExprKind::Lit(ref lit) = args.first().unwrap().node {
+                            if let ast::LitKind::Str(ref s, _) = lit.node {
+                                return Some(Key::UniCase(UniCase(s.to_string())));
+                            } else {
+                                cx.span_err(e.span, "only a str literal is allowed in UniCase");
+                                return None;
+                            }
+                        }
+                    } else {
+                        cx.span_err(e.span, "only one str literal is allowed in UniCase");
+                        return None;
+                    }
+                }
+            }
+            cx.span_err(e.span, "only UniCase is allowed besides literals");
+            None
+        },
         _ => {
-            cx.span_err(e.span, "expected a literal");
+            cx.span_err(e.span, "expected a literal (or a UniCase if the unicase_support feature is enabled)");
             None
         }
     }

--- a/phf_macros/src/util.rs
+++ b/phf_macros/src/util.rs
@@ -25,6 +25,8 @@ pub enum Key {
     U64(u64),
     I64(i64),
     Bool(bool),
+    #[cfg(feature = "unicase_support")]
+    UniCase(::unicase::UniCase<String>),
 }
 
 impl Hash for Key {
@@ -42,6 +44,8 @@ impl Hash for Key {
             Key::U64(b) => b.hash(state),
             Key::I64(b) => b.hash(state),
             Key::Bool(b) => b.hash(state),
+            #[cfg(feature = "unicase_support")]
+            Key::UniCase(ref u) => u.hash(state),
         }
     }
 }
@@ -61,6 +65,8 @@ impl PhfHash for Key {
             Key::U64(b) => b.phf_hash(state),
             Key::I64(b) => b.phf_hash(state),
             Key::Bool(b) => b.phf_hash(state),
+            #[cfg(feature = "unicase_support")]
+            Key::UniCase(ref u) => u.phf_hash(state),
         }
     }
 }

--- a/phf_macros/tests/compile-fail-unicase/equivalent-keys.rs
+++ b/phf_macros/tests/compile-fail-unicase/equivalent-keys.rs
@@ -1,0 +1,10 @@
+#![feature(plugin)]
+#![plugin(phf_macros)]
+
+extern crate phf;
+extern crate unicase;
+
+static MAP: phf::Map<UniCase<&'static str>, isize> = phf_map!( //~ ERROR duplicate key UniCase("FOO")
+    UniCase("FOO") => 42, //~ NOTE one occurrence here
+    UniCase("foo") => 42, //~ NOTE one occurrence here
+);

--- a/phf_macros/tests/compiletest.rs
+++ b/phf_macros/tests/compiletest.rs
@@ -14,11 +14,6 @@ fn run_mode(directory: &'static str, mode: &'static str) {
     compiletest::run_tests(&config);
 }
 
-// #[test]
-// fn compile_test() {
-//     run_mode("compile-fail", "compile-fail");
-// }
-
 #[cfg(feature = "unicase_support")]
 #[test]
 fn compile_test_unicase() {

--- a/phf_macros/tests/compiletest.rs
+++ b/phf_macros/tests/compiletest.rs
@@ -1,0 +1,26 @@
+extern crate compiletest_rs as compiletest;
+
+use std::path::PathBuf;
+
+#[allow(dead_code)]
+fn run_mode(directory: &'static str, mode: &'static str) {
+    let mut config = compiletest::default_config();
+    let cfg_mode = mode.parse().ok().expect("Invalid mode");
+
+    config.mode = cfg_mode;
+    config.target_rustcflags = Some("-L target/debug/".to_owned());
+    config.src_base = PathBuf::from(format!("tests/{}", directory));
+
+    compiletest::run_tests(&config);
+}
+
+// #[test]
+// fn compile_test() {
+//     run_mode("compile-fail", "compile-fail");
+// }
+
+#[cfg(feature = "unicase_support")]
+#[test]
+fn compile_test_unicase() {
+    run_mode("compile-fail-unicase", "compile-fail");
+}

--- a/phf_macros/tests/test.rs
+++ b/phf_macros/tests/test.rs
@@ -2,6 +2,8 @@
 #![plugin(phf_macros)]
 
 extern crate phf;
+#[cfg(feature = "unicase_support")]
+extern crate unicase;
 
 mod map {
     use std::collections::{HashMap, HashSet};
@@ -230,6 +232,32 @@ mod map {
             assert_eq!(&"foo", k);
             assert_eq!(&10, v)
         }
+    }
+
+    #[cfg(feature = "unicase_support")]
+    #[test]
+    fn test_unicase() {
+        use unicase::UniCase;
+        static MAP: phf::Map<UniCase<&'static str>, isize> = phf_map!(
+            UniCase("FOO") => 10,
+            UniCase("Bar") => 11,
+        );
+        assert!(Some(&10) == MAP.get(&UniCase("FOo")));
+        assert!(Some(&11) == MAP.get(&UniCase("bar")));
+        assert_eq!(None, MAP.get(&UniCase("asdf")));
+    }
+
+    #[cfg(feature = "unicase_support")]
+    #[test]
+    fn test_unicase_alt() {
+        use unicase;
+        static MAP: phf::Map<unicase::UniCase<&'static str>, isize> = phf_map!(
+            unicase::UniCase("FOO") => 10,
+            unicase::UniCase("Bar") => 11,
+        );
+        assert!(Some(&10) == MAP.get(&unicase::UniCase("FOo")));
+        assert!(Some(&11) == MAP.get(&unicase::UniCase("bar")));
+        assert_eq!(None, MAP.get(&unicase::UniCase("asdf")));
     }
 }
 

--- a/phf_shared/Cargo.toml
+++ b/phf_shared/Cargo.toml
@@ -16,4 +16,4 @@ test = false
 core = []
 
 [dependencies]
-unicase = { version = "1.1", optional = true }
+unicase = { version = "1.4", optional = true }


### PR DESCRIPTION
This is actually my first time doing anything compiler/plugin related so this may be pretty bad...
Any pointers to improvements are highly welcome.

I'm not sure if there's a better solution regarding the naming of the feature (related: https://github.com/rust-lang/cargo/issues/1286 by you :smile:)