### PR TITLE
Improve benchmark

### DIFF
--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -27,4 +27,5 @@ unicase = { version = "1.4", optional = true }
 [dev-dependencies]
 phf = { version = "0.7.21", path = "../phf" }
 compiletest_rs = "0.2"
+fnv = "1.0.3"
 

--- a/phf_macros/benches/bench.rs
+++ b/phf_macros/benches/bench.rs
@@ -6,6 +6,7 @@ extern crate phf;
 
 mod map {
     use std::collections::{BTreeMap, HashMap};
+    use test;
     use test::Bencher;
 
     use phf;
@@ -57,14 +58,14 @@ mod map {
     #[bench]
     fn bench_match_some(b: &mut Bencher) {
         b.iter(|| {
-            assert_eq!(match_get("zucchini").unwrap(), 25);
+            assert_eq!(match_get(test::black_box("zucchini")).unwrap(), 25);
         })
     }
 
     #[bench]
     fn bench_match_none(b: &mut Bencher) {
         b.iter(|| {
-            assert_eq!(match_get("potato"), None);
+            assert_eq!(test::black_box(match_get("potato")), None);
         })
     }
 
@@ -114,7 +115,7 @@ mod map {
 
     #[bench]
     fn bench_hashmap_none(b: &mut Bencher) {
-        let mut map = BTreeMap::new();
+        let mut map = HashMap::new();
         for (key, value) in MAP.entries() {
             map.insert(*key, *value);
         }

--- a/phf_macros/benches/bench.rs
+++ b/phf_macros/benches/bench.rs
@@ -2,10 +2,12 @@
 #![plugin(phf_macros)]
 
 extern crate test;
+extern crate fnv;
 extern crate phf;
 
 mod map {
     use std::collections::{BTreeMap, HashMap};
+    use fnv::FnvHashMap;
     use test;
     use test::Bencher;
 
@@ -94,6 +96,18 @@ mod map {
     }
 
     #[bench]
+    fn bench_hashmap_fnv_some(b: &mut Bencher) {
+        let mut map = FnvHashMap::default();
+        for (key, value) in MAP.entries() {
+            map.insert(*key, *value);
+        }
+
+        b.iter(|| {
+            assert_eq!(map.get("zucchini").unwrap(), &25);
+        })
+    }
+
+    #[bench]
     fn bench_phf_some(b: &mut Bencher) {
         b.iter(|| {
             assert_eq!(MAP.get("zucchini").unwrap(), &25);
@@ -112,10 +126,21 @@ mod map {
         })
     }
 
-
     #[bench]
     fn bench_hashmap_none(b: &mut Bencher) {
         let mut map = HashMap::new();
+        for (key, value) in MAP.entries() {
+            map.insert(*key, *value);
+        }
+
+        b.iter(|| {
+            assert_eq!(map.get("potato"), None);
+        })
+    }
+
+    #[bench]
+    fn bench_hashmap_fnv_none(b: &mut Bencher) {
+        let mut map = FnvHashMap::default();
         for (key, value) in MAP.entries() {
             map.insert(*key, *value);
         }


### PR DESCRIPTION
Original benchmark misused BTreeMap in benchmark item `bench_hashmap_none()`, and mis-optimized `bench_match_some()` and `bench_match_none`, which makes the results remain 0ns consistently.

I also added benchmarks against Fnv-HashMap, because somebody may be interested by theirs results.