### PR TITLE
Upgrade UniCase to 2.0 [BREAKING CHANGE]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rust:
 script:
 - cargo clean
 - (test $TRAVIS_RUST_VERSION != "nightly" || cargo test --manifest-path phf_macros/Cargo.toml --features unicase_support)
+- cargo clean # otherwise compiletest complains about multiple matching crates
 - (test $TRAVIS_RUST_VERSION != "nightly" || cargo test --manifest-path phf_macros/Cargo.toml)
 - (test $TRAVIS_RUST_VERSION != "nightly" || cargo bench --manifest-path phf_macros/Cargo.toml)
 - (test $TRAVIS_RUST_VERSION != "nightly" || cargo build --manifest-path phf/Cargo.toml --features core)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,5 @@
 [workspace]
 members = ["phf", "phf_builder", "phf_codegen", "phf_codegen/test", "phf_generator", "phf_macros", "phf_shared"]
+
+[patch.crates-io]
+unicase = { git = 'https://github.com/Bobo1239/unicase.git' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 members = ["phf", "phf_builder", "phf_codegen", "phf_codegen/test", "phf_generator", "phf_macros", "phf_shared"]
 
-[patch.crates-io]
-unicase = { git = 'https://github.com/Bobo1239/unicase.git' }
+[replace]
+"unicase:2.0.0" = { git = 'https://github.com/Bobo1239/unicase.git' }

--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -166,8 +166,8 @@ impl<K: Hash+PhfHash+Eq+fmt::Debug> Map<K> {
         for &idx in &state.map {
             try!(write!(w,
                         "
-        ({:?}, {}),",
-                        &self.keys[idx],
+        ({}, {}),",
+                        &self.keys[idx].as_expression(),
                         &self.values[idx]));
         }
         write!(w,

--- a/phf_codegen/test/Cargo.toml
+++ b/phf_codegen/test/Cargo.toml
@@ -5,10 +5,10 @@ version = "0.0.0"
 build = "build.rs"
 
 [dependencies]
-unicase = "1.1"
+unicase = "2.0"
 
 [build-dependencies]
-unicase = "1.1"
+unicase = "2.0"
 
 [build-dependencies.phf_codegen]
 path = ".."

--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
-use unicase::UniCase;
+use unicase::Ascii;
 
 fn main() {
     let file = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");
@@ -57,11 +57,11 @@ fn main() {
         .unwrap();
     write!(&mut file, ";\n").unwrap();
 
-    write!(&mut file, "static UNICASE_MAP: ::phf::Map<::unicase::UniCase<&'static str>, \
+    write!(&mut file, "static UNICASE_MAP: ::phf::Map<::unicase::Ascii<&'static str>, \
                                                       &'static str> = ").unwrap();
     phf_codegen::Map::new()
-        .entry(UniCase("abc"), "\"a\"")
-        .entry(UniCase("DEF"), "\"b\"")
+        .entry(Ascii::new("abc"), "\"a\"")
+        .entry(Ascii::new("DEF"), "\"b\"")
         .build(&mut file)
         .unwrap();
     write!(&mut file, ";\n").unwrap();

--- a/phf_codegen/test/src/lib.rs
+++ b/phf_codegen/test/src/lib.rs
@@ -3,7 +3,7 @@ extern crate unicase;
 
 #[cfg(test)]
 mod test {
-    use unicase::UniCase;
+    use unicase::Ascii;
 
     include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
 
@@ -50,9 +50,9 @@ mod test {
 
     #[test]
     fn unicase_map() {
-        assert_eq!("a", UNICASE_MAP[&UniCase("AbC")]);
-        assert_eq!("a", UNICASE_MAP[&UniCase("abc")]);
-        assert_eq!("b", UNICASE_MAP[&UniCase("DEf")]);
-        assert!(!UNICASE_MAP.contains_key(&UniCase("XyZ")));
+        assert_eq!("a", UNICASE_MAP[&Ascii::new("AbC")]);
+        assert_eq!("a", UNICASE_MAP[&Ascii::new("abc")]);
+        assert_eq!("b", UNICASE_MAP[&Ascii::new("DEf")]);
+        assert!(!UNICASE_MAP.contains_key(&Ascii::new("XyZ")));
     }
 }

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -22,10 +22,9 @@ stats = []
 [dependencies]
 phf_generator = { version = "=0.7.21", path = "../phf_generator" }
 phf_shared = { version = "=0.7.21", path = "../phf_shared" }
-unicase = { version = "1.4", optional = true }
+unicase = { version = "2.0", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 phf = { version = "0.7.21", path = "../phf" }
-compiletest_rs = "0.2"
+compiletest_rs = "0.3"
 fnv = "1.0.3"
-

--- a/phf_macros/src/util.rs
+++ b/phf_macros/src/util.rs
@@ -27,6 +27,8 @@ pub enum Key {
     Bool(bool),
     #[cfg(feature = "unicase_support")]
     UniCase(::unicase::UniCase<String>),
+    #[cfg(feature = "unicase_support")]
+    UniCaseAscii(::unicase::Ascii<String>),
 }
 
 impl Hash for Key {
@@ -46,6 +48,8 @@ impl Hash for Key {
             Key::Bool(b) => b.hash(state),
             #[cfg(feature = "unicase_support")]
             Key::UniCase(ref u) => u.hash(state),
+            #[cfg(feature = "unicase_support")]
+            Key::UniCaseAscii(ref u) => u.hash(state),
         }
     }
 }
@@ -67,6 +71,8 @@ impl PhfHash for Key {
             Key::Bool(b) => b.phf_hash(state),
             #[cfg(feature = "unicase_support")]
             Key::UniCase(ref u) => u.phf_hash(state),
+            #[cfg(feature = "unicase_support")]
+            Key::UniCaseAscii(ref u) => u.phf_hash(state),
         }
     }
 }

--- a/phf_macros/tests/compile-fail-unicase/equivalent-keys-ascii.rs
+++ b/phf_macros/tests/compile-fail-unicase/equivalent-keys-ascii.rs
@@ -1,0 +1,12 @@
+#![feature(plugin)]
+#![plugin(phf_macros)]
+
+extern crate phf;
+extern crate unicase;
+
+use unicase::Ascii;
+
+static MAP: phf::Map<Ascii<&'static str>, isize> = phf_map!( //~ ERROR duplicate key Ascii::new("FOO")
+    Ascii::new("FOO") => 42, //~ NOTE one occurrence here
+    Ascii::new("foo") => 42, //~ NOTE one occurrence here
+);

--- a/phf_macros/tests/compile-fail-unicase/equivalent-keys.rs
+++ b/phf_macros/tests/compile-fail-unicase/equivalent-keys.rs
@@ -4,7 +4,9 @@
 extern crate phf;
 extern crate unicase;
 
-static MAP: phf::Map<UniCase<&'static str>, isize> = phf_map!( //~ ERROR duplicate key UniCase("FOO")
-    UniCase("FOO") => 42, //~ NOTE one occurrence here
-    UniCase("foo") => 42, //~ NOTE one occurrence here
+use unicase::UniCase;
+
+static MAP: phf::Map<UniCase<&'static str>, isize> = phf_map!( //~ ERROR duplicate key UniCase::unicode("Ma\u{df}e")
+    UniCase::unicode("Maße") => 42, //~ NOTE one occurrence here
+    UniCase::unicode("MASSE") => 42, //~ NOTE one occurrence here
 );

--- a/phf_macros/tests/compiletest.rs
+++ b/phf_macros/tests/compiletest.rs
@@ -2,9 +2,11 @@ extern crate compiletest_rs as compiletest;
 
 use std::path::Path;
 
+use compiletest::Config;
+
 #[allow(dead_code)]
 fn run_mode(directory: &'static str, mode: &'static str) {
-    let mut config = compiletest::default_config();
+    let mut config = Config::default();
     let cfg_mode = mode.parse().ok().expect("Invalid mode");
 
     config.mode = cfg_mode;

--- a/phf_macros/tests/test.rs
+++ b/phf_macros/tests/test.rs
@@ -239,25 +239,41 @@ mod map {
     fn test_unicase() {
         use unicase::UniCase;
         static MAP: phf::Map<UniCase<&'static str>, isize> = phf_map!(
-            UniCase("FOO") => 10,
-            UniCase("Bar") => 11,
+            UniCase::unicode("Maße") => 10,
+            UniCase::unicode("Grüße") => 11,
         );
-        assert!(Some(&10) == MAP.get(&UniCase("FOo")));
-        assert!(Some(&11) == MAP.get(&UniCase("bar")));
-        assert_eq!(None, MAP.get(&UniCase("asdf")));
+        assert!(Some(&10) == MAP.get(&UniCase::unicode("MASSE")));
+        assert!(Some(&11) == MAP.get(&UniCase::unicode("gRÜSSE")));
+        assert_eq!(None, MAP.get(&UniCase::unicode("asdf")));
     }
 
     #[cfg(feature = "unicase_support")]
     #[test]
-    fn test_unicase_alt() {
-        use unicase;
-        static MAP: phf::Map<unicase::UniCase<&'static str>, isize> = phf_map!(
-            unicase::UniCase("FOO") => 10,
-            unicase::UniCase("Bar") => 11,
+    fn test_unicase_ascii() {
+        use unicase::Ascii;
+        static MAP: phf::Map<Ascii<&'static str>, isize> = phf_map!(
+            Ascii("FOO") => 10,
+            Ascii("Bar") => 11,
         );
-        assert!(Some(&10) == MAP.get(&unicase::UniCase("FOo")));
-        assert!(Some(&11) == MAP.get(&unicase::UniCase("bar")));
-        assert_eq!(None, MAP.get(&unicase::UniCase("asdf")));
+        assert!(Some(&10) == MAP.get(&Ascii("FOo")));
+        assert!(Some(&11) == MAP.get(&Ascii("bar")));
+        assert_eq!(None, MAP.get(&Ascii("asdf")));
+    }
+
+    #[cfg(feature = "unicase_support")]
+    #[test]
+    fn test_unicase_different_syntaxes() {
+        use unicase::{self, Ascii};
+        static MAP: phf::Map<Ascii<&'static str>, isize> = phf_map!(
+            Ascii::new("FOO") => 10,
+            unicase::Ascii::new("Bar") => 11,
+            Ascii("baZ") => 13,
+            unicase::Ascii("qUx") => 14,
+        );
+        assert!(Some(&10) == MAP.get(&Ascii("FOo")));
+        assert!(Some(&11) == MAP.get(&Ascii("bar")));
+        assert!(Some(&13) == MAP.get(&Ascii("baz")));
+        assert!(Some(&14) == MAP.get(&Ascii("qux")));
     }
 }
 

--- a/phf_shared/Cargo.toml
+++ b/phf_shared/Cargo.toml
@@ -17,4 +17,4 @@ core = []
 
 [dependencies]
 siphasher = "0.2"
-unicase = { version = "1.4", optional = true }
+unicase = { version = "2.0", optional = true }

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -64,6 +64,12 @@ pub trait PhfHash {
             piece.phf_hash(state);
         }
     }
+
+    // Used for codegen
+    #[cfg(not(feature = "core"))]
+    fn as_expression(&self) -> String where Self: core::fmt::Debug {
+        format!("{:?}", self)
+    }
 }
 
 #[cfg(not(feature = "core"))]
@@ -113,6 +119,23 @@ impl PhfHash for [u8] {
 #[cfg(feature = "unicase")]
 impl<S> PhfHash for unicase::UniCase<S>
 where unicase::UniCase<S>: Hash {
+    #[inline]
+    fn phf_hash<H: Hasher>(&self, state: &mut H) {
+        self.hash(state)
+    }
+
+    #[cfg(not(feature = "core"))]
+    fn as_expression(&self) -> String where Self: core::fmt::Debug {
+        panic!("Can't use UniCase for phf_codegen as only const functions can \
+                be called in statics (const functions are unstable). Maybe try \
+                unicase::Ascii?");
+        // format!("::unicase::UniCase::new({:?})", self)
+    }
+}
+
+#[cfg(feature = "unicase")]
+impl<S> PhfHash for unicase::Ascii<S>
+where unicase::Ascii<S>: Hash {
     #[inline]
     fn phf_hash<H: Hasher>(&self, state: &mut H) {
         self.hash(state)


### PR DESCRIPTION
Depends on some changes in UniCase. (which may or may not have a chance of getting upstreamed; see https://github.com/Bobo1239/unicase; somewhat relevant: https://github.com/seanmonstar/unicase/pull/14#r69232957)
`Ascii` is basically what the old `UniCase` was and the new `UniCase` can now additionally handle unicode case folding.
Tbh I'm not sure if the breakage is worth it just to get a dependency up to date. (And personally I can't think of an example where one would need a HashMap which handles unicode case folding)
Consider this PR an experiment and let me know if I should further pursue this or not.