### PR TITLE
Update to latest nightly

### DIFF
--- a/phf_macros/src/util.rs
+++ b/phf_macros/src/util.rs
@@ -6,14 +6,14 @@ use syntax::codemap::Span;
 use syntax::ext::base::{ExtCtxt, MacResult, MacEager};
 use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
-use syntax::symbol::InternedString;
+use syntax::symbol::LocalInternedString;
 
 use phf_shared::PhfHash;
 use phf_generator::HashState;
 
 #[derive(PartialEq, Eq, Clone)]
 pub enum Key {
-    Str(InternedString),
+    Str(LocalInternedString),
     Binary(Rc<Vec<u8>>),
 }
 


### PR DESCRIPTION
This fixes compilation errors on the latest nightly relating to the `InternedString` type.
I simply switched to using the `LocalInternedString` type which fixes the errors and makes the tests pass.

Please release a new version with this fix, so I can properly fix my dependencies.