### PR TITLE
Make `build` method in `phf_codegen` return displayable structs

### DIFF
--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -132,7 +132,7 @@ impl<K: Hash+PhfHash+Eq+Debug> Map<K> {
         self
     }
 
-    /// Constructs a `phf::Map`, outputting a displayable struct.
+    /// Constructs a `phf::Map`, returning a `Display` implementor.
     ///
     /// # Panics
     ///
@@ -213,7 +213,7 @@ impl<T: Hash+PhfHash+Eq+Debug> Set<T> {
         self
     }
 
-    /// Constructs a `phf::Set`, outputting Rust source to the provided writer.
+    /// Constructs a `phf::Set`, returning a `Display` implementor.
     ///
     /// # Panics
     ///
@@ -267,8 +267,7 @@ impl<K: Hash+PhfHash+Eq+Debug> OrderedMap<K> {
         self
     }
 
-    /// Constructs a `phf::OrderedMap`, outputting Rust source to the provided
-    /// writer.
+    /// Constructs a `phf::OrderedMap`, returning a `Display` implementor.
     ///
     /// # Panics
     ///
@@ -359,8 +358,7 @@ impl<T: Hash+PhfHash+Eq+Debug> OrderedSet<T> {
         self
     }
 
-    /// Constructs a `phf::OrderedSet`, outputting Rust source to the provided
-    /// writer.
+    /// Constructs a `phf::OrderedSet`, returning a `Display` implementor.
     ///
     /// # Panics
     ///

--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -12,57 +12,63 @@ fn main() {
     let file = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");
     let mut file = BufWriter::new(File::create(&file).unwrap());
 
-    write!(&mut file, "static MAP: ::phf::Map<u32, &'static str> = ").unwrap();
-    phf_codegen::Map::new()
-        .entry(1u32, "\"a\"")
-        .entry(2u32, "\"b\"")
-        .entry(3u32, "\"c\"")
-        .build(&mut file)
-        .unwrap();
-    write!(&mut file, ";\n").unwrap();
+    write!(
+        &mut file,
+        "static MAP: ::phf::Map<u32, &'static str> = {};\n",
+        phf_codegen::Map::new()
+            .entry(1u32, "\"a\"")
+            .entry(2u32, "\"b\"")
+            .entry(3u32, "\"c\"")
+            .build()
+    ).unwrap();
 
-    write!(&mut file, "static SET: ::phf::Set<u32> = ").unwrap();
-    phf_codegen::Set::new()
-        .entry(1u32)
-        .entry(2u32)
-        .entry(3u32)
-        .build(&mut file)
-        .unwrap();
-    write!(&mut file, ";\n").unwrap();
+    write!(
+        &mut file,
+        "static SET: ::phf::Set<u32> = {};\n",
+        phf_codegen::Set::new()
+            .entry(1u32)
+            .entry(2u32)
+            .entry(3u32)
+            .build()
+    ).unwrap();
 
-    write!(&mut file, "static ORDERED_MAP: ::phf::OrderedMap<u32, &'static str> = ").unwrap();
-    phf_codegen::OrderedMap::new()
-        .entry(1u32, "\"a\"")
-        .entry(2u32, "\"b\"")
-        .entry(3u32, "\"c\"")
-        .build(&mut file)
-        .unwrap();
-    write!(&mut file, ";\n").unwrap();
+    write!(
+        &mut file,
+        "static ORDERED_MAP: ::phf::OrderedMap<u32, &'static str> = {};\n",
+        phf_codegen::OrderedMap::new()
+            .entry(1u32, "\"a\"")
+            .entry(2u32, "\"b\"")
+            .entry(3u32, "\"c\"")
+            .build()
+    ).unwrap();
 
-    write!(&mut file, "static ORDERED_SET: ::phf::OrderedSet<u32> = ").unwrap();
-    phf_codegen::OrderedSet::new()
-        .entry(1u32)
-        .entry(2u32)
-        .entry(3u32)
-        .build(&mut file)
-        .unwrap();
-    write!(&mut file, ";\n").unwrap();
+    write!(
+        &mut file,
+        "static ORDERED_SET: ::phf::OrderedSet<u32> = {};\n",
+        phf_codegen::OrderedSet::new()
+            .entry(1u32)
+            .entry(2u32)
+            .entry(3u32)
+            .build()
+    ).unwrap();
 
-    write!(&mut file, "static STR_KEYS: ::phf::Map<&'static str, u32> = ").unwrap();
-    phf_codegen::Map::new()
-        .entry("a", "1")
-        .entry("b", "2")
-        .entry("c", "3")
-        .build(&mut file)
-        .unwrap();
-    write!(&mut file, ";\n").unwrap();
+    write!(
+        &mut file,
+        "static STR_KEYS: ::phf::Map<&'static str, u32> = {};\n",
+        phf_codegen::Map::new()
+            .entry("a", "1")
+            .entry("b", "2")
+            .entry("c", "3")
+            .build(),
+    ).unwrap();
 
-    write!(&mut file, "static UNICASE_MAP: ::phf::Map<::unicase::UniCase<&'static str>, \
-                                                      &'static str> = ").unwrap();
-    phf_codegen::Map::new()
-        .entry(UniCase("abc"), "\"a\"")
-        .entry(UniCase("DEF"), "\"b\"")
-        .build(&mut file)
-        .unwrap();
-    write!(&mut file, ";\n").unwrap();
+    write!(
+        &mut file,
+        "static UNICASE_MAP: ::phf::Map<::unicase::UniCase<&'static str>, \
+         &'static str> = {};\n",
+        phf_codegen::Map::new()
+            .entry(UniCase("abc"), "\"a\"")
+            .entry(UniCase("DEF"), "\"b\"")
+            .build(),
+    ).unwrap()
 }


### PR DESCRIPTION
As discussed in  #133, this PR makes `phf_codegen::Map.build` and `phf_codegen::Set.build`.

Example from the `phf_codegen/lib.rs`:
```rust
     write!(
         &mut file,
         "static KEYWORDS: phf::Map<&'static str, Keyword> = {};\n",
         phf_codegen::Map::new()
             .entry("loop", "Keyword::Loop")
             .entry("continue", "Keyword::Continue")
             .entry("break", "Keyword::Break")
             .entry("fn", "Keyword::Fn")
             .entry("extern", "Keyword::Extern")
             .build(),
     ).unwrap();
```

`Map.build` returns a struct that is bound to the `Map` reference lifetime, so that the map can be written several times but the hasher state is only generated once, and the `MapView` must go out of scope before the map is modified again. 

The function now returns directly instead of a `Result`, since it will either `panic` or always succeed;