### PR TITLE
Added Display (and other traits) to phf-codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,16 @@ fn main() {
     let path = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");
     let mut file = BufWriter::new(File::create(&path).unwrap());
 
-    write!(&mut file, "static KEYWORDS: phf::Map<&'static str, Keyword> = ").unwrap();
-    phf_codegen::Map::new()
-        .entry("loop", "Keyword::Loop")
-        .entry("continue", "Keyword::Continue")
-        .entry("break", "Keyword::Break")
-        .entry("fn", "Keyword::Fn")
-        .entry("extern", "Keyword::Extern")
-        .build(&mut file)
-        .unwrap();
-    write!(&mut file, ";\n").unwrap();
+    write!(
+        &mut file,
+        "static KEYWORDS: phf::Map<&'static str, Keyword> = {};\n",
+        phf_codegen::Map::new()
+            .entry("loop", "Keyword::Loop")
+            .entry("continue", "Keyword::Continue")
+            .entry("break", "Keyword::Break")
+            .entry("fn", "Keyword::Fn")
+            .entry("extern", "Keyword::Extern")
+    ).unwrap();
 }
 ```
 

--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -21,17 +21,16 @@
 //!     let path = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");
 //!     let mut file = BufWriter::new(File::create(&path).unwrap());
 //!
-//! write!(&mut file, "static KEYWORDS: phf::Map<&'static str, Keyword> =
-//! ").unwrap();
-//!     phf_codegen::Map::new()
-//!         .entry("loop", "Keyword::Loop")
-//!         .entry("continue", "Keyword::Continue")
-//!         .entry("break", "Keyword::Break")
-//!         .entry("fn", "Keyword::Fn")
-//!         .entry("extern", "Keyword::Extern")
-//!         .build(&mut file)
-//!         .unwrap();
-//!     write!(&mut file, ";\n").unwrap();
+//!     write!(
+//!         &mut file,
+//!         "static KEYWORDS: phf::Map<&'static str, Keyword> = {};\n",
+//!         phf_codegen::Map::new()
+//!             .entry("loop", "Keyword::Loop")
+//!             .entry("continue", "Keyword::Continue")
+//!             .entry("break", "Keyword::Break")
+//!             .entry("fn", "Keyword::Fn")
+//!             .entry("extern", "Keyword::Extern")
+//!     ).unwrap();
 //! }
 //! ```
 //!

--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -78,16 +78,16 @@
 //! builder.entry("world", "2");
 //! // ...
 //! ```
-#![doc(html_root_url="https://docs.rs/phf_codegen/0.7")]
-extern crate phf_shared;
+#![doc(html_root_url = "https://docs.rs/phf_codegen/0.7")]
 extern crate phf_generator;
+extern crate phf_shared;
 
 use phf_shared::PhfHash;
 use std::collections::HashSet;
-use std::fmt::{self, Formatter, Display};
+use std::default::Default;
+use std::fmt::{self, Display, Formatter};
 use std::hash::Hash;
 use std::io;
-use std::default::Default;
 use std::io::prelude::*;
 
 /// A builder for the `phf::Map` type.
@@ -98,7 +98,7 @@ pub struct Map<K> {
     path: String,
 }
 
-impl<K: Hash+PhfHash+Eq+fmt::Debug> Map<K> {
+impl<K: Hash + PhfHash + Eq + fmt::Debug> Map<K> {
     /// Creates a new `phf::Map` builder.
     pub fn new() -> Map<K> {
         // FIXME rust#27438
@@ -108,8 +108,7 @@ impl<K: Hash+PhfHash+Eq+fmt::Debug> Map<K> {
         // the linker ends up throwing a way a bunch of static symbols we actually need.
         // This works around the problem, assuming that all clients call `Map::new` by
         // calling a non-generic function.
-        fn noop_fix_for_27438() {
-        }
+        fn noop_fix_for_27438() {}
         noop_fix_for_27438();
 
         Map {
@@ -150,7 +149,7 @@ impl<K: Hash + PhfHash + Eq + fmt::Debug> Default for Map<K> {
     }
 }
 
-impl<K: Hash+PhfHash+Eq+fmt::Debug> Display for Map<K> {
+impl<K: Hash + PhfHash + Eq + fmt::Debug> Display for Map<K> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let mut set = HashSet::new();
         for key in &self.keys {
@@ -161,33 +160,42 @@ impl<K: Hash+PhfHash+Eq+fmt::Debug> Display for Map<K> {
 
         let state = phf_generator::generate_hash(&self.keys);
 
-        try!(write!(f,
-                    "{}::Map {{
+        try!(write!(
+            f,
+            "{}::Map {{
     key: {},
     disps: {}::Slice::Static(&[",
-                    self.path, state.key, self.path));
+            self.path, state.key, self.path
+        ));
         for &(d1, d2) in &state.disps {
-            try!(write!(f,
-                        "
+            try!(write!(
+                f,
+                "
         ({}, {}),",
-                        d1,
-                        d2));
+                d1, d2
+            ));
         }
-        try!(write!(f,
-                    "
+        try!(write!(
+            f,
+            "
     ]),
-    entries: {}::Slice::Static(&[", self.path));
+    entries: {}::Slice::Static(&[",
+            self.path
+        ));
         for &idx in &state.map {
-            try!(write!(f,
-                        "
+            try!(write!(
+                f,
+                "
         ({:?}, {}),",
-                        &self.keys[idx],
-                        &self.values[idx]));
+                &self.keys[idx], &self.values[idx]
+            ));
         }
-        write!(f,
-               "
+        write!(
+            f,
+            "
     ]),
-}}")
+}}"
+        )
     }
 }
 
@@ -197,12 +205,10 @@ pub struct Set<T> {
     map: Map<T>,
 }
 
-impl<T: Hash+PhfHash+Eq+fmt::Debug> Set<T> {
+impl<T: Hash + PhfHash + Eq + fmt::Debug> Set<T> {
     /// Constructs a new `phf::Set` builder.
     pub fn new() -> Set<T> {
-        Set {
-            map: Map::new(),
-        }
+        Set { map: Map::new() }
     }
 
     /// Set the path to the `phf` crate from the global namespace
@@ -247,7 +253,7 @@ pub struct OrderedMap<K> {
     path: String,
 }
 
-impl<K: Hash+PhfHash+Eq+fmt::Debug> OrderedMap<K> {
+impl<K: Hash + PhfHash + Eq + fmt::Debug> OrderedMap<K> {
     /// Constructs a enw `phf::OrderedMap` builder.
     pub fn new() -> OrderedMap<K> {
         OrderedMap {
@@ -283,13 +289,13 @@ impl<K: Hash+PhfHash+Eq+fmt::Debug> OrderedMap<K> {
     }
 }
 
-impl<K: Hash+PhfHash+Eq+fmt::Debug> Default for OrderedMap<K> {
+impl<K: Hash + PhfHash + Eq + fmt::Debug> Default for OrderedMap<K> {
     fn default() -> Self {
         OrderedMap::new()
     }
 }
 
-impl<K: Hash+PhfHash+Eq+fmt::Debug> Display for OrderedMap<K> {
+impl<K: Hash + PhfHash + Eq + fmt::Debug> Display for OrderedMap<K> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let mut set = HashSet::new();
         for key in &self.keys {
@@ -300,32 +306,42 @@ impl<K: Hash+PhfHash+Eq+fmt::Debug> Display for OrderedMap<K> {
 
         let state = phf_generator::generate_hash(&self.keys);
 
-        try!(write!(f,
-                    "{}::OrderedMap {{
+        try!(write!(
+            f,
+            "{}::OrderedMap {{
     key: {},
     disps: {}::Slice::Static(&[",
-                    self.path, state.key, self.path));
+            self.path, state.key, self.path
+        ));
         for &(d1, d2) in &state.disps {
-            try!(write!(f,"\n        ({}, {}),", d1, d2));
+            try!(write!(f, "\n        ({}, {}),", d1, d2));
         }
-        try!(write!(f,
-                    "
+        try!(write!(
+            f,
+            "
     ]),
-    idxs: {}::Slice::Static(&[", self.path));
+    idxs: {}::Slice::Static(&[",
+            self.path
+        ));
         for &idx in &state.map {
             try!(write!(f, "\n        {},", idx));
         }
-        try!(write!(f,
-                    "
+        try!(write!(
+            f,
+            "
     ]),
-    entries: {}::Slice::Static(&[", self.path));
+    entries: {}::Slice::Static(&[",
+            self.path
+        ));
         for (key, value) in self.keys.iter().zip(self.values.iter()) {
             try!(write!(f, "\n        ({:?}, {}),", key, value));
         }
-        write!(f,
-               "
+        write!(
+            f,
+            "
     ]),
-}}")
+}}"
+        )
     }
 }
 
@@ -335,7 +351,7 @@ pub struct OrderedSet<T> {
     map: OrderedMap<T>,
 }
 
-impl<T: Hash+PhfHash+Eq+fmt::Debug> OrderedSet<T> {
+impl<T: Hash + PhfHash + Eq + fmt::Debug> OrderedSet<T> {
     /// Constructs a new `phf::OrderedSet` builder.
     pub fn new() -> OrderedSet<T> {
         OrderedSet {

--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -30,7 +30,11 @@ fn main() {
         .unwrap();
     write!(&mut file, ";\n").unwrap();
 
-    write!(&mut file, "static ORDERED_MAP: ::phf::OrderedMap<u32, &'static str> = ").unwrap();
+    write!(
+        &mut file,
+        "static ORDERED_MAP: ::phf::OrderedMap<u32, &'static str> = "
+    )
+    .unwrap();
     phf_codegen::OrderedMap::new()
         .entry(1u32, "\"a\"")
         .entry(2u32, "\"b\"")
@@ -48,7 +52,11 @@ fn main() {
         .unwrap();
     write!(&mut file, ";\n").unwrap();
 
-    write!(&mut file, "static STR_KEYS: ::phf::Map<&'static str, u32> = ").unwrap();
+    write!(
+        &mut file,
+        "static STR_KEYS: ::phf::Map<&'static str, u32> = "
+    )
+    .unwrap();
     phf_codegen::Map::new()
         .entry("a", "1")
         .entry("b", "2")
@@ -57,8 +65,12 @@ fn main() {
         .unwrap();
     write!(&mut file, ";\n").unwrap();
 
-    write!(&mut file, "static UNICASE_MAP: ::phf::Map<::unicase::UniCase<&'static str>, \
-                                                      &'static str> = ").unwrap();
+    write!(
+        &mut file,
+        "static UNICASE_MAP: ::phf::Map<::unicase::UniCase<&'static str>, \
+         &'static str> = "
+    )
+    .unwrap();
     phf_codegen::Map::new()
         .entry(UniCase("abc"), "\"a\"")
         .entry(UniCase("DEF"), "\"b\"")
@@ -66,39 +78,40 @@ fn main() {
         .unwrap();
     write!(&mut file, ";\n").unwrap();
 
-    let mut formatted_map = phf_codegen::Map::new();
+    write!(
+        &mut file,
+        "static FORMATTED_MAP: phf::Map<&'static str, u32> = {};\n",
+        phf_codegen::Map::new()
+            .entry("a", "1")
+            .entry("b", "2")
+            .entry("c", "3")
+    )
+    .unwrap();
 
-    formatted_map
-        .entry("a", "1")
-        .entry("b", "2")
-        .entry("c", "3");
+    write!(
+        &mut file,
+        "static FORMATTED_ORDERED_MAP: phf::OrderedMap<&'static str, u32> = {};\n",
+        phf_codegen::OrderedMap::new()
+            .entry("a", "1")
+            .entry("b", "2")
+            .entry("c", "3")
+    )
+    .unwrap();
 
-    write!(&mut file, "static FORMATTED_MAP: phf::Map<&'static str, u32> = {};\n", formatted_map).unwrap();
+    write!(
+        &mut file,
+        "static FORMATTED_SET: phf::Set<&'static str> = {};\n",
+        phf_codegen::Set::new().entry("a").entry("b").entry("c")
+    )
+    .unwrap();
 
-    let mut formatted_ordered_map = phf_codegen::OrderedMap::new();
-
-    formatted_ordered_map
-        .entry("a", "1")
-        .entry("b", "2")
-        .entry("c", "3");
-
-    write!(&mut file, "static FORMATTED_ORDERED_MAP: phf::OrderedMap<&'static str, u32> = {};\n", formatted_ordered_map).unwrap();
-
-    let mut formatted_set = phf_codegen::Set::new();
-
-    formatted_set
-        .entry("a")
-        .entry("b")
-        .entry("c");
-
-    write!(&mut file, "static FORMATTED_SET: phf::Set<&'static str> = {};\n", formatted_set).unwrap();
-
-    let mut formatted_ordered_set = phf_codegen::OrderedSet::new();
-
-    formatted_ordered_set
-        .entry("a")
-        .entry("b")
-        .entry("c");
-
-    write!(&mut file, "static FORMATTED_ORDERED_SET: phf::OrderedSet<&'static str> = {};\n", formatted_ordered_set).unwrap();
+    write!(
+        &mut file,
+        "static FORMATTED_ORDERED_SET: phf::OrderedSet<&'static str> = {};\n",
+        phf_codegen::OrderedSet::new()
+            .entry("a")
+            .entry("b")
+            .entry("c")
+    )
+    .unwrap();
 }

--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -80,7 +80,7 @@ fn main() {
 
     write!(
         &mut file,
-        "static FORMATTED_MAP: phf::Map<&'static str, u32> = {};\n",
+        "static FORMATTED_MAP: ::phf::Map<&'static str, u32> = {};\n",
         phf_codegen::Map::new()
             .entry("a", "1")
             .entry("b", "2")
@@ -90,7 +90,7 @@ fn main() {
 
     write!(
         &mut file,
-        "static FORMATTED_ORDERED_MAP: phf::OrderedMap<&'static str, u32> = {};\n",
+        "static FORMATTED_ORDERED_MAP: ::phf::OrderedMap<&'static str, u32> = {};\n",
         phf_codegen::OrderedMap::new()
             .entry("a", "1")
             .entry("b", "2")
@@ -100,14 +100,14 @@ fn main() {
 
     write!(
         &mut file,
-        "static FORMATTED_SET: phf::Set<&'static str> = {};\n",
+        "static FORMATTED_SET: ::phf::Set<&'static str> = {};\n",
         phf_codegen::Set::new().entry("a").entry("b").entry("c")
     )
     .unwrap();
 
     write!(
         &mut file,
-        "static FORMATTED_ORDERED_SET: phf::OrderedSet<&'static str> = {};\n",
+        "static FORMATTED_ORDERED_SET: ::phf::OrderedSet<&'static str> = {};\n",
         phf_codegen::OrderedSet::new()
             .entry("a")
             .entry("b")

--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -65,4 +65,40 @@ fn main() {
         .build(&mut file)
         .unwrap();
     write!(&mut file, ";\n").unwrap();
+
+    let mut formatted_map = phf_codegen::Map::new();
+
+    formatted_map
+        .entry("a", "1")
+        .entry("b", "2")
+        .entry("c", "3");
+
+    write!(&mut file, "static FORMATTED_MAP: phf::Map<&'static str, u32> = {};\n", formatted_map).unwrap();
+
+    let mut formatted_ordered_map = phf_codegen::OrderedMap::new();
+
+    formatted_ordered_map
+        .entry("a", "1")
+        .entry("b", "2")
+        .entry("c", "3");
+
+    write!(&mut file, "static FORMATTED_ORDERED_MAP: phf::OrderedMap<&'static str, u32> = {};\n", formatted_ordered_map).unwrap();
+
+    let mut formatted_set = phf_codegen::Set::new();
+
+    formatted_set
+        .entry("a")
+        .entry("b")
+        .entry("c");
+
+    write!(&mut file, "static FORMATTED_SET: phf::Set<&'static str> = {};\n", formatted_set).unwrap();
+
+    let mut formatted_ordered_set = phf_codegen::OrderedSet::new();
+
+    formatted_ordered_set
+        .entry("a")
+        .entry("b")
+        .entry("c");
+
+    write!(&mut file, "static FORMATTED_ORDERED_SET: phf::OrderedSet<&'static str> = {};\n", formatted_ordered_set).unwrap();
 }

--- a/phf_codegen/test/src/lib.rs
+++ b/phf_codegen/test/src/lib.rs
@@ -29,7 +29,10 @@ mod test {
         assert_eq!("b", ORDERED_MAP[&2]);
         assert_eq!("c", ORDERED_MAP[&3]);
         assert!(!ORDERED_MAP.contains_key(&100));
-        assert_eq!(&["a", "b", "c"][..], &ORDERED_MAP.values().cloned().collect::<Vec<_>>()[..]);
+        assert_eq!(
+            &["a", "b", "c"][..],
+            &ORDERED_MAP.values().cloned().collect::<Vec<_>>()[..]
+        );
     }
 
     #[test]
@@ -38,7 +41,10 @@ mod test {
         assert!(ORDERED_SET.contains(&2));
         assert!(ORDERED_SET.contains(&3));
         assert!(!ORDERED_SET.contains(&4));
-        assert_eq!(&[1, 2, 3][..], &ORDERED_SET.iter().cloned().collect::<Vec<_>>()[..]);
+        assert_eq!(
+            &[1, 2, 3][..],
+            &ORDERED_SET.iter().cloned().collect::<Vec<_>>()[..]
+        );
     }
 
     #[test]
@@ -81,8 +87,14 @@ mod test {
         assert_eq!(FORMATTED_ORDERED_MAP["c"], 3);
         assert!(!FORMATTED_ORDERED_MAP.contains_key("d"));
         assert!(!FORMATTED_ORDERED_MAP.contains_key("A"));
-        assert_eq!(&FORMATTED_ORDERED_MAP.keys().cloned().collect::<Vec<_>>(), &["a", "b", "c"]);
-        assert_eq!(&FORMATTED_ORDERED_MAP.values().cloned().collect::<Vec<_>>(), &[1, 2, 3]);
+        assert_eq!(
+            &FORMATTED_ORDERED_MAP.keys().cloned().collect::<Vec<_>>(),
+            &["a", "b", "c"]
+        );
+        assert_eq!(
+            &FORMATTED_ORDERED_MAP.values().cloned().collect::<Vec<_>>(),
+            &[1, 2, 3]
+        );
     }
 
     #[test]
@@ -92,6 +104,9 @@ mod test {
         assert!(FORMATTED_ORDERED_SET.contains("c"));
         assert!(!FORMATTED_ORDERED_SET.contains("d"));
         assert!(!FORMATTED_ORDERED_SET.contains("A"));
-        assert_eq!(&FORMATTED_ORDERED_SET.iter().cloned().collect::<Vec<_>>(), &["a", "b", "c"]);
+        assert_eq!(
+            &FORMATTED_ORDERED_SET.iter().cloned().collect::<Vec<_>>(),
+            &["a", "b", "c"]
+        );
     }
 }

--- a/phf_codegen/test/src/lib.rs
+++ b/phf_codegen/test/src/lib.rs
@@ -55,4 +55,43 @@ mod test {
         assert_eq!("b", UNICASE_MAP[&UniCase("DEf")]);
         assert!(!UNICASE_MAP.contains_key(&UniCase("XyZ")));
     }
+
+    #[test]
+    fn formatted_map() {
+        assert_eq!(FORMATTED_MAP["a"], 1);
+        assert_eq!(FORMATTED_MAP["b"], 2);
+        assert_eq!(FORMATTED_MAP["c"], 3);
+        assert!(!FORMATTED_MAP.contains_key("d"));
+        assert!(!FORMATTED_MAP.contains_key("A"));
+    }
+
+    #[test]
+    fn formatted_set() {
+        assert!(FORMATTED_SET.contains("a"));
+        assert!(FORMATTED_SET.contains("b"));
+        assert!(FORMATTED_SET.contains("c"));
+        assert!(!FORMATTED_SET.contains("d"));
+        assert!(!FORMATTED_SET.contains("A"));
+    }
+
+    #[test]
+    fn formatted_ordered_map() {
+        assert_eq!(FORMATTED_ORDERED_MAP["a"], 1);
+        assert_eq!(FORMATTED_ORDERED_MAP["b"], 2);
+        assert_eq!(FORMATTED_ORDERED_MAP["c"], 3);
+        assert!(!FORMATTED_ORDERED_MAP.contains_key("d"));
+        assert!(!FORMATTED_ORDERED_MAP.contains_key("A"));
+        assert_eq!(&FORMATTED_ORDERED_MAP.keys().cloned().collect::<Vec<_>>(), &["a", "b", "c"]);
+        assert_eq!(&FORMATTED_ORDERED_MAP.values().cloned().collect::<Vec<_>>(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn formatted_ordered_set() {
+        assert!(FORMATTED_ORDERED_SET.contains("a"));
+        assert!(FORMATTED_ORDERED_SET.contains("b"));
+        assert!(FORMATTED_ORDERED_SET.contains("c"));
+        assert!(!FORMATTED_ORDERED_SET.contains("d"));
+        assert!(!FORMATTED_ORDERED_SET.contains("A"));
+        assert_eq!(&FORMATTED_ORDERED_SET.iter().cloned().collect::<Vec<_>>(), &["a", "b", "c"]);
+    }
 }


### PR DESCRIPTION
In order to streamline the use of phf-codegen, I've added a `Display` implementation to all of the builder structs, to supplant the `build` method. This allows you to use the builders inline in `write!` calls, which means it's now much more clear how to embed the data structure in a statement.

Example:

```rust
write!(
    dest,
    "static KEYWORDS: phf::Map<&'static str, Keyword> = {};\n"
    phf_codegen::Map::new()
        .entry("loop", "Keyword::Loop")
        .entry("continue", Keyword::Continue")
        // etc
).unwrap();
```

This pull request includes tests for all the changes.

I've also added trivial implementations of `Debug`, `Clone`, and `Default`, consistent with Rust best practices.

Fixes #133