### PR TITLE
Fix & include tests for empty maps

### DIFF
--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -80,6 +80,7 @@ impl<K, V> Map<K, V> {
         where T: Eq + PhfHash,
               K: Borrow<T>
     {
+        if self.disps.len() == 0 { return None; } //Prevent panic on empty map
         let hash = phf_shared::hash(key, self.key);
         let index = phf_shared::get_index(hash, &*self.disps, self.entries.len());
         let entry = &self.entries[index as usize];

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -108,6 +108,7 @@ impl<K, V> OrderedMap<K, V> {
         where T: Eq + PhfHash,
               K: Borrow<T>
     {
+        if self.disps.len() == 0 { return None; } //Prevent panic on empty map
         let hash = phf_shared::hash(key, self.key);
         let idx_index = phf_shared::get_index(hash, &*self.disps, self.idxs.len());
         let idx = self.idxs[idx_index as usize];

--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -65,4 +65,13 @@ fn main() {
         .build(&mut file)
         .unwrap();
     write!(&mut file, ";\n").unwrap();
+
+    //u32 is used here purely for a type that impls `Hash+PhfHash+Eq+fmt::Debug`, but is not required for the empty test itself
+    write!(&mut file, "static EMPTY: ::phf::Map<u32, u32> = ").unwrap();
+    phf_codegen::Map::<u32>::new().build(&mut file).unwrap();
+    write!(&mut file, ";\n").unwrap();
+
+    write!(&mut file, "static EMPTY_ORDERED: ::phf::OrderedMap<u32, u32> = ").unwrap();
+    phf_codegen::OrderedMap::<u32>::new().build(&mut file).unwrap();
+    write!(&mut file, ";\n").unwrap();
 }

--- a/phf_codegen/test/src/lib.rs
+++ b/phf_codegen/test/src/lib.rs
@@ -55,4 +55,15 @@ mod test {
         assert_eq!("b", UNICASE_MAP[&UniCase("DEf")]);
         assert!(!UNICASE_MAP.contains_key(&UniCase("XyZ")));
     }
+
+     #[test]
+    fn empty_map() {
+        assert_eq!(None, EMPTY.get(&1));
+    }
+
+     #[test]
+    fn empty_ordered_map() {
+        assert_eq!(None, EMPTY_ORDERED.get(&1));
+    }
+
 }


### PR DESCRIPTION
This is basically a rewrite of https://github.com/sfackler/rust-phf/pull/116 which appears to have been moved to the `next` branch, but I can't see from the history of this repo why this change has never made it to `master`.

There are a few minor changes around the type checker and the inclusion of an extra test for ordered map.

Let me know if there was a reason around the initial PR not making it to `master`, and I am happy to close this PR off and just use my fork for the time being.