### PR TITLE
Fixed typo in benchmark

### DIFF
--- a/phf_macros/benches/bench.rs
+++ b/phf_macros/benches/bench.rs
@@ -112,7 +112,7 @@ mod map {
 
     #[bench]
     fn bench_hashmap_none(b: &mut Bencher) {
-        let mut map = BTreeMap::new();
+        let mut map = HashMap::new();
         for (key, value) in MAP.entries() {
             map.insert(*key, *value);
         }


### PR DESCRIPTION
The benchmark labeled `hasmap_none` is actually using `BTreeMap`. I assume this is a typo.