### PR TITLE
Changed macros to work on stable (with proc-macro-hack)

### DIFF
--- a/phf/Cargo.toml
+++ b/phf/Cargo.toml
@@ -15,9 +15,17 @@ test = false
 [features]
 core = ["phf_shared/core"]
 unicase = ["phf_shared/unicase"]
-macros = ["phf_macros"]
+macros = [
+	"phf_macros",
+	"proc-macro-hack",
+]
 
 [dependencies]
 phf_shared = { version = "0.7.24", path = "../phf_shared" }
 
+proc-macro-hack = { version = "0.5.4", optional = true }
 phf_macros = { version = "0.7.24", optional = true, path = "../phf_macros" }
+
+[package.metadata.docs.rs]
+features = ["macros", ]
+

--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -7,7 +7,8 @@
 //!
 //! If the `macros` Cargo feature is enabled, the `phf_map`, `phf_set`,
 //! `phf_ordered_map`, and `phf_ordered_set` macros can be used to construct
-//! the PHF type. This currently requires a nightly compiler.
+//! the PHF type. This method can be used with a stable compiler
+//! (`rustc` version 1.30+)
 //!
 //! ```toml
 //! [dependencies]
@@ -15,8 +16,6 @@
 //! ```
 //!
 //! ```
-//! #![feature(proc_macro_hygiene)]
-//!
 //! use phf::{phf_map, phf_set};
 //!
 //! static MY_MAP: phf::Map<&'static str, u32> = phf_map! {
@@ -35,8 +34,8 @@
 //! }
 //! ```
 //!
-//! Alternatively, you can use the phf_codegen crate to generate PHF datatypes
-//! in a build script. This method can be used with a stable compiler.
+//! (Alternatively, you can use the phf_codegen crate to generate PHF datatypes
+//! in a build script)
 #![doc(html_root_url="https://docs.rs/phf/0.7")]
 #![warn(missing_docs)]
 #![cfg_attr(feature = "core", no_std)]
@@ -45,7 +44,65 @@
 extern crate std as core;
 
 #[cfg(feature = "macros")]
-pub use phf_macros::*;
+/// Macro to create a `static` (compile-time) [`Map`].
+///
+/// Requires the `"macros"` feature.
+///
+/// # Example
+///
+/// ```rust,edition2018
+/// use ::phf::{phf_map, Map};
+///
+/// static MY_MAP: Map<&'static str, u32> = phf_map! {
+///     "hello" => 1,
+///     "world" => 2,
+/// };
+///
+/// fn main ()
+/// {
+///     assert_eq!(MY_MAP["hello"], 1);
+/// }
+/// ```
+#[::proc_macro_hack::proc_macro_hack]
+pub use phf_macros:: phf_map;
+
+#[cfg(feature = "macros")]
+/// Macro to create a `static` (compile-time) [`OrderedMap`].
+///
+/// Requires the `"macros"` feature. Same usage as [`phf_map`]`!`.
+#[::proc_macro_hack::proc_macro_hack]
+pub use phf_macros::phf_ordered_map;
+
+#[cfg(feature = "macros")]
+/// Macro to create a `static` (compile-time) [`Set`].
+///
+/// Requires the `"macros"` feature.
+///
+/// # Example
+///
+/// ```rust,edition2018
+/// use ::phf::{phf_set, Set};
+///
+/// static MY_SET: Set<&'static str> = phf_set! {
+///     "hello world",
+///     "hola mundo",
+/// };
+///
+/// fn main ()
+/// {
+///     assert!(MY_SET.contains("hello world"));
+/// }
+/// ```
+#[::proc_macro_hack::proc_macro_hack]
+pub use phf_macros::phf_set;
+
+#[cfg(feature = "macros")]
+/// Macro to create a `static` (compile-time) [`OrderedSet`].
+///
+/// Requires the `"macros"` feature. Same usage as [`phf_set`]`!`.
+#[::proc_macro_hack::proc_macro_hack]
+pub use phf_macros::phf_ordered_set;
+
 
 use core::ops::Deref;
 

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -14,10 +14,11 @@ proc-macro = true
 syn = { version = "0.15", features = ["full"] }
 quote = "0.6"
 proc-macro2 = "0.4"
+proc-macro-hack = "0.5.4"
 
 phf_generator = { version = "0.7.24", path = "../phf_generator" }
 phf_shared = { version = "0.7.24", path = "../phf_shared" }
 
 [dev-dependencies]
-compiletest_rs = "0.3"
+compiletest_rs = "0.3.22"
 phf = { version = "0.7", path = "../phf", features = ["macros"] }

--- a/phf_macros/src/lib.rs
+++ b/phf_macros/src/lib.rs
@@ -259,7 +259,7 @@ fn build_ordered_map(entries: &[Entry], state: HashState) -> proc_macro2::TokenS
     }
 }
 
-#[proc_macro]
+#[::proc_macro_hack::proc_macro_hack]
 pub fn phf_map(input: TokenStream) -> TokenStream {
     let map = parse_macro_input!(input as Map);
     let state = phf_generator::generate_hash(&map.0);
@@ -267,7 +267,7 @@ pub fn phf_map(input: TokenStream) -> TokenStream {
     build_map(&map.0, state).into()
 }
 
-#[proc_macro]
+#[::proc_macro_hack::proc_macro_hack]
 pub fn phf_set(input: TokenStream) -> TokenStream {
     let set = parse_macro_input!(input as Set);
     let state = phf_generator::generate_hash(&set.0);
@@ -276,7 +276,7 @@ pub fn phf_set(input: TokenStream) -> TokenStream {
     quote!(phf::Set { map: #map }).into()
 }
 
-#[proc_macro]
+#[::proc_macro_hack::proc_macro_hack]
 pub fn phf_ordered_map(input: TokenStream) -> TokenStream {
     let map = parse_macro_input!(input as Map);
     let state = phf_generator::generate_hash(&map.0);
@@ -284,7 +284,7 @@ pub fn phf_ordered_map(input: TokenStream) -> TokenStream {
     build_ordered_map(&map.0, state).into()
 }
 
-#[proc_macro]
+#[::proc_macro_hack::proc_macro_hack]
 pub fn phf_ordered_set(input: TokenStream) -> TokenStream {
     let set = parse_macro_input!(input as Set);
     let state = phf_generator::generate_hash(&set.0);


### PR DESCRIPTION
`proc-macro-hack`-based (much simpler) reimplementation of https://github.com/sfackler/rust-phf/pull/148, to address https://github.com/sfackler/rust-phf/issues/106