### PR TITLE
Upgrade UniCase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   stable:
     docker:
-      - image: rust:1.25.0-slim
+      - image: rust:1.31.0-slim
     environment:
       RUSTFLAGS: -D warnings
     steps:

--- a/phf/Cargo.toml
+++ b/phf/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.7.24"
 license = "MIT"
 description = "Runtime support for perfect hash function data structures"
 repository = "https://github.com/sfackler/rust-phf"
+edition = "2018"
 
 [lib]
 name = "phf"

--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -44,10 +44,6 @@
 #[cfg(not(feature = "core"))]
 extern crate std as core;
 
-extern crate phf_shared;
-#[cfg(feature = "macros")]
-extern crate phf_macros;
-
 #[cfg(feature = "macros")]
 pub use phf_macros::*;
 
@@ -55,13 +51,13 @@ use core::ops::Deref;
 
 pub use phf_shared::PhfHash;
 #[doc(inline)]
-pub use map::Map;
+pub use self::map::Map;
 #[doc(inline)]
-pub use set::Set;
+pub use self::set::Set;
 #[doc(inline)]
-pub use ordered_map::OrderedMap;
+pub use self::ordered_map::OrderedMap;
 #[doc(inline)]
-pub use ordered_set::OrderedSet;
+pub use self::ordered_set::OrderedSet;
 
 pub mod map;
 pub mod set;

--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -5,7 +5,7 @@ use core::slice;
 use core::fmt;
 use core::iter::IntoIterator;
 use phf_shared::{self, PhfHash};
-use Slice;
+use crate::Slice;
 
 /// An immutable map constructed at compile time.
 ///

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::slice;
 use phf_shared::{self, PhfHash};
 
-use Slice;
+use crate::Slice;
 
 /// An order-preserving immutable map constructed at compile time.
 ///

--- a/phf/src/ordered_set.rs
+++ b/phf/src/ordered_set.rs
@@ -2,8 +2,7 @@
 use core::borrow::Borrow;
 use core::iter::IntoIterator;
 use core::fmt;
-use ordered_map;
-use {PhfHash, OrderedMap};
+use crate::{ordered_map, PhfHash, OrderedMap};
 
 /// An order-preserving immutable set constructed at compile time.
 ///

--- a/phf/src/set.rs
+++ b/phf/src/set.rs
@@ -3,9 +3,7 @@ use core::borrow::Borrow;
 use core::iter::IntoIterator;
 use core::fmt;
 
-use PhfHash;
-use map;
-use Map;
+use crate::{map, Map, PhfHash};
 
 /// An immutable set constructed at compile time.
 ///

--- a/phf_codegen/test/Cargo.toml
+++ b/phf_codegen/test/Cargo.toml
@@ -5,10 +5,10 @@ version = "0.0.0"
 build = "build.rs"
 
 [dependencies]
-unicase = "1.1"
+unicase = "2.4.0"
 
 [build-dependencies]
-unicase = "1.1"
+unicase = "2.4.0"
 
 [build-dependencies.phf_codegen]
 path = ".."

--- a/phf_codegen/test/Cargo.toml
+++ b/phf_codegen/test/Cargo.toml
@@ -3,6 +3,7 @@ name = "phf_codegen_test"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 version = "0.0.0"
 build = "build.rs"
+edition = "2018"
 
 [dependencies]
 unicase = "2.4.0"

--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -60,8 +60,8 @@ fn main() {
     write!(&mut file, "static UNICASE_MAP: ::phf::Map<::unicase::UniCase<&'static str>, \
                                                       &'static str> = ").unwrap();
     phf_codegen::Map::new()
-        .entry(UniCase("abc"), "\"a\"")
-        .entry(UniCase("DEF"), "\"b\"")
+        .entry(UniCase::new("abc"), "\"a\"")
+        .entry(UniCase::new("DEF"), "\"b\"")
         .build(&mut file)
         .unwrap();
     write!(&mut file, ";\n").unwrap();

--- a/phf_codegen/test/src/lib.rs
+++ b/phf_codegen/test/src/lib.rs
@@ -50,10 +50,10 @@ mod test {
 
     #[test]
     fn unicase_map() {
-        assert_eq!("a", UNICASE_MAP[&UniCase("AbC")]);
-        assert_eq!("a", UNICASE_MAP[&UniCase("abc")]);
-        assert_eq!("b", UNICASE_MAP[&UniCase("DEf")]);
-        assert!(!UNICASE_MAP.contains_key(&UniCase("XyZ")));
+        assert_eq!("a", UNICASE_MAP[&UniCase::new("AbC")]);
+        assert_eq!("a", UNICASE_MAP[&UniCase::new("abc")]);
+        assert_eq!("b", UNICASE_MAP[&UniCase::new("DEf")]);
+        assert!(!UNICASE_MAP.contains_key(&UniCase::new("XyZ")));
     }
 
      #[test]

--- a/phf_codegen/test/src/lib.rs
+++ b/phf_codegen/test/src/lib.rs
@@ -1,6 +1,3 @@
-extern crate phf;
-extern crate unicase;
-
 #[cfg(test)]
 mod test {
     use unicase::UniCase;

--- a/phf_generator/Cargo.toml
+++ b/phf_generator/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.7.24"
 license = "MIT"
 description = "PHF generation logic"
 repository = "https://github.com/sfackler/rust-phf"
+edition = "2018"
 
 [dependencies]
 rand = "0.6"

--- a/phf_shared/Cargo.toml
+++ b/phf_shared/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.7.24"
 license = "MIT"
 description = "Support code shared by PHF libraries"
 repository = "https://github.com/sfackler/rust-phf"
+edition = "2018"
 
 [lib]
 name = "phf_shared"

--- a/phf_shared/Cargo.toml
+++ b/phf_shared/Cargo.toml
@@ -16,4 +16,4 @@ core = []
 
 [dependencies]
 siphasher = "0.2"
-unicase = { version = "1.4", optional = true }
+unicase = { version = "2.4.0", optional = true }

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -152,10 +152,15 @@ where unicase::UniCase<S>: Hash {
 }
 
 #[cfg(feature = "unicase")]
-impl<S> FmtConst for unicase::UniCase<S> where S: FmtConst {
+impl<S> FmtConst for unicase::UniCase<S> where S: AsRef<str> {
     fn fmt_const(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("UniCase(")?;
-        self.0.fmt_const(f)?;
+        if self.is_ascii() {
+            f.write_str("UniCase::ascii(")?;
+        } else {
+            f.write_str("UniCase::unicode(")?;
+        }
+
+        self.as_ref().fmt_const(f)?;
         f.write_str(")")
     }
 }


### PR DESCRIPTION
closes #143

- [x] Introduce a new trait `FmtConst` for printing const exprs of types which delegates to `fmt::Debug` where applicable instead of always relying on it
- [x] Upgrade `unicase` to ^2.4*
    - [x] Merge seanmonstar/unicase#30