### PR TITLE
implement support for 128-bit ints and fix high magnitude values

### DIFF
--- a/phf_macros/tests/test.rs
+++ b/phf_macros/tests/test.rs
@@ -166,42 +166,60 @@ mod map {
 
     #[test]
     fn test_i8_keys() {
-        test_key_type!(i8, 0i8 => 0, 1i8 => 1);
+        test_key_type!(i8, 0i8 => 0, 1i8 => 1, 127i8 => 2, -128i8 => 3);
     }
 
     #[test]
     fn test_i16_keys() {
-        test_key_type!(i16, 0i16 => 0, 1i16 => 1);
+        test_key_type!(i16, 0i16 => 0, 1i16 => 1, 32767i16 => 2, -32768i16 => 3);
     }
 
     #[test]
     fn test_i32_keys() {
-        test_key_type!(i32, 0i32 => 0, 1i32 => 1);
+        test_key_type!(i32, 0i32 => 0, 1i32 => 1, 2147483647i32 => 2, -2147483648i32 => 3);
     }
 
     #[test]
     fn test_i64_keys() {
-        test_key_type!(i64, 0i64 => 0, 1i64 => 1);
+        test_key_type!(i64, 0i64 => 0, 1i64 => 1, -9223372036854775808i64 => 2);
+    }
+
+    #[test]
+    fn test_i128_keys() {
+        test_key_type!(
+            i128, 0i128 => 0, 1i128 => 1,
+            // `syn` handles literals larger than 64-bit differently
+            170141183460469231731687303715884105727i128 => 2,
+            -170141183460469231731687303715884105727i128 => 3
+        );
     }
 
     #[test]
     fn test_u8_keys() {
-        test_key_type!(u8, 0u8 => 0, 1u8 => 1);
+        test_key_type!(u8, 0u8 => 0, 1u8 => 1, 255u8 => 2);
     }
 
     #[test]
     fn test_u16_keys() {
-        test_key_type!(u16, 0u16 => 0, 1u16 => 1);
+        test_key_type!(u16, 0u16 => 0, 1u16 => 1, 65535u16 => 2);
     }
 
     #[test]
     fn test_u32_keys() {
-        test_key_type!(u32, 0u32 => 0, 1u32 => 1);
+        test_key_type!(u32, 0u32 => 0, 1u32 => 1, 4294967295u32 => 2);
     }
 
     #[test]
     fn test_u64_keys() {
-        test_key_type!(u64, 0u64 => 0, 1u64 => 1);
+        test_key_type!(u64, 0u64 => 0, 1u64 => 1, 18446744073709551615u64 => 2);
+    }
+
+    #[test]
+    fn test_u128_keys() {
+        test_key_type!(
+            u128, 0u128 => 0, 1u128 => 1,
+            340282366920938463463374607431768211455u128 => 2
+        );
     }
 
     #[test]

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -98,6 +98,8 @@ delegate_debug!(u32);
 delegate_debug!(i32);
 delegate_debug!(u64);
 delegate_debug!(i64);
+delegate_debug!(u128);
+delegate_debug!(i128);
 delegate_debug!(bool);
 
 #[cfg(not(feature = "core"))]
@@ -192,6 +194,8 @@ sip_impl!(le u32);
 sip_impl!(le i32);
 sip_impl!(le u64);
 sip_impl!(le i64);
+sip_impl!(le u128);
+sip_impl!(le i128);
 sip_impl!(bool);
 
 impl PhfHash for char {


### PR DESCRIPTION
closes #129 

When testing u128 literals (which `syn` handles differently for large values) I found a bug in the current macro code that prevented use of large magnitude negative values so I went ahead and fixed that and documented the reasoning.