### PR TITLE
fix `FmtConst` for `[u8]`

### DIFF
--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -88,7 +88,6 @@ macro_rules! delegate_debug(
 );
 
 delegate_debug!(str);
-delegate_debug!([u8]);
 delegate_debug!(char);
 delegate_debug!(u8);
 delegate_debug!(i8);
@@ -141,6 +140,14 @@ impl PhfHash for [u8] {
     #[inline]
     fn phf_hash<H: Hasher>(&self, state: &mut H) {
         state.write(self);
+    }
+}
+
+impl FmtConst for [u8] {
+    #[inline]
+    fn fmt_const(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // slices need a leading reference
+        write!(f, "&{:?}", self)
     }
 }
 


### PR DESCRIPTION
closes #151

@sfackler this is technically a breaking change if someone is using byte slices already but using an array as the emitted type. (This was a latent bug from before my refactor that I inadvertently included.) However given that it's counterintuitive behavior I doubt very many people are making use of it or expecting it to continue working this way.