### PR TITLE
[breaking] create `Display` adapters for `phf_codegen` builders

### DIFF
--- a/phf_codegen/Cargo.toml
+++ b/phf_codegen/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.7.24"
 license = "MIT"
 description = "Codegen library for PHF types"
 repository = "https://github.com/sfackler/rust-phf"
+edition = "2018"
 
 [dependencies]
 phf_generator = { version = "0.7.24", path = "../phf_generator" }

--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -12,79 +12,87 @@ fn main() -> io::Result<()> {
     let file = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");
     let mut file = BufWriter::new(File::create(&file)?);
 
-    write!(&mut file, "static MAP: ::phf::Map<u32, &'static str> = ")?;
-    phf_codegen::Map::new()
-        .entry(1u32, "\"a\"")
-        .entry(2u32, "\"b\"")
-        .entry(3u32, "\"c\"")
-        .build(&mut file)?;
-    write!(&mut file, ";\n")?;
+    writeln!(
+        &mut file,
+        "static MAP: ::phf::Map<u32, &'static str> = \n{};",
+        phf_codegen::Map::new()
+            .entry(1u32, "\"a\"")
+            .entry(2u32, "\"b\"")
+            .entry(3u32, "\"c\"")
+            .build()
+    )?;
 
-    write!(&mut file, "static SET: ::phf::Set<u32> = ")?;
-    phf_codegen::Set::new()
-        .entry(1u32)
-        .entry(2u32)
-        .entry(3u32)
-        .build(&mut file)?;
-    write!(&mut file, ";\n")?;
+    writeln!(
+        &mut file,
+        "static SET: ::phf::Set<u32> = \n{};",
+        phf_codegen::Set::new()
+            .entry(1u32)
+            .entry(2u32)
+            .entry(3u32)
+            .build()
+    )?;
 
-    write!(&mut file, "static ORDERED_MAP: ::phf::OrderedMap<u32, &'static str> = ")?;
-    phf_codegen::OrderedMap::new()
-        .entry(1u32, "\"a\"")
-        .entry(2u32, "\"b\"")
-        .entry(3u32, "\"c\"")
-        .build(&mut file)?;
-    write!(&mut file, ";\n")?;
+    writeln!(
+        &mut file,
+        "static ORDERED_MAP: ::phf::OrderedMap<u32, &'static str> = \n{};",
+        phf_codegen::OrderedMap::new()
+            .entry(1u32, "\"a\"")
+            .entry(2u32, "\"b\"")
+            .entry(3u32, "\"c\"")
+            .build()
+    )?;
 
-    write!(&mut file, "static ORDERED_SET: ::phf::OrderedSet<u32> = ")?;
-    phf_codegen::OrderedSet::new()
-        .entry(1u32)
-        .entry(2u32)
-        .entry(3u32)
-        .build(&mut file)?;
-    write!(&mut file, ";\n")?;
+    writeln!(
+        &mut file,
+        "static ORDERED_SET: ::phf::OrderedSet<u32> = \n{};",
+        phf_codegen::OrderedSet::new()
+            .entry(1u32)
+            .entry(2u32)
+            .entry(3u32)
+            .build()
+    )?;
 
-    write!(&mut file, "static STR_KEYS: ::phf::Map<&'static str, u32> = ")?;
-    phf_codegen::Map::new()
-        .entry("a", "1")
-        .entry("b", "2")
-        .entry("c", "3")
-        .build(&mut file)?;
-    write!(&mut file, ";\n")?;
+    writeln!(
+        &mut file,
+        "static STR_KEYS: ::phf::Map<&'static str, u32> = \n{};",
+        phf_codegen::Map::new()
+            .entry("a", "1")
+            .entry("b", "2")
+            .entry("c", "3")
+            .build()
+    )?;
 
-    write!(&mut file, "static UNICASE_MAP: ::phf::Map<::unicase::UniCase<&'static str>, \
-                                                      &'static str> = ")?;
-    phf_codegen::Map::new()
-        .entry(UniCase::new("abc"), "\"a\"")
-        .entry(UniCase::new("DEF"), "\"b\"")
-        .build(&mut file)?;
-    write!(&mut file, ";\n")?;
+    write!(
+        &mut file,
+        "static UNICASE_MAP: ::phf::Map<::unicase::UniCase<&'static str>, &'static str> = \n{};",
+        phf_codegen::Map::new()
+            .entry(UniCase::new("abc"), "\"a\"")
+            .entry(UniCase::new("DEF"), "\"b\"")
+            .build()
+    )?;
 
     //u32 is used here purely for a type that impls `Hash+PhfHash+Eq+fmt::Debug`, but is not required for the empty test itself
-    write!(&mut file, "static EMPTY: ::phf::Map<u32, u32> = ")?;
-    phf_codegen::Map::<u32>::new().build(&mut file)?;
-    write!(&mut file, ";\n")?;
+    writeln!(&mut file,
+             "static EMPTY: ::phf::Map<u32, u32> = \n{};",
+             phf_codegen::Map::<u32>::new().build())?;
 
-    write!(&mut file, "static EMPTY_ORDERED: ::phf::OrderedMap<u32, u32> = ")?;
-    phf_codegen::OrderedMap::<u32>::new().build(&mut file)?;
-    write!(&mut file, ";\n")?;
+    writeln!(&mut file,
+             "static EMPTY_ORDERED: ::phf::OrderedMap<u32, u32> = \n{};",
+             phf_codegen::OrderedMap::<u32>::new().build())?;
 
-    write!(&mut file, "static ARRAY_KEYS: ::phf::Map<[u8; 3], u32> = ")?;
-    phf_codegen::Map::<[u8; 3]>::new()
-        .entry(*b"foo", "0")
-        .entry(*b"bar", "1")
-        .entry(*b"baz", "2")
-        .build(&mut file)?;
+    writeln!(&mut file, "static ARRAY_KEYS: ::phf::Map<[u8; 3], u32> = \n{};",
+             phf_codegen::Map::<[u8; 3]>::new()
+                 .entry(*b"foo", "0")
+                 .entry(*b"bar", "1")
+                 .entry(*b"baz", "2")
+                 .build())?;
 
-    writeln!(&mut file, ";")?;
-
-    write!(&mut file, "static BYTE_STR_KEYS: ::phf::Map<&[u8], u32> = ")?;
     // key type required here as it will infer `&'static [u8; 3]` instead
-    phf_codegen::Map::<&[u8]>::new()
-        .entry(b"foo", "0")
-        .entry(b"bar", "1")
-        .entry(b"baz", "2")
-        .entry(b"quux", "3")
-        .build(&mut file)?;
-    writeln!(&mut file, ";")
+    writeln!(&mut file, "static BYTE_STR_KEYS: ::phf::Map<&[u8], u32> = \n{};",
+             phf_codegen::Map::<&[u8]>::new()
+                 .entry(b"foo", "0")
+                 .entry(b"bar", "1")
+                 .entry(b"baz", "2")
+                 .entry(b"quux", "3")
+                 .build())
 }

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -20,5 +20,6 @@ phf_generator = { version = "0.7.24", path = "../phf_generator" }
 phf_shared = { version = "0.7.24", path = "../phf_shared" }
 
 [dev-dependencies]
-compiletest_rs = "0.3.22"
+# requires nightly to build and dev-deps can't be optional
+# compiletest_rs = "0.3.22"
 phf = { version = "0.7", path = "../phf", features = ["macros"] }

--- a/phf_macros/tests/compiletest.rs
+++ b/phf_macros/tests/compiletest.rs
@@ -1,3 +1,5 @@
+#![cfg(compiletest)]
+
 extern crate compiletest_rs as compiletest;
 
 use compiletest::Config;


### PR DESCRIPTION
supercedes #136, #141 since those PRs are out of date.

I decided to keep the `build()` method intact because changing its signature would be a pretty confusing breaking change, and I don't like the idea of hiding a `generate_hash()` call directly in a `Display` impl.

Also updated the code here to use `?` instead of `try!()` because it was about time.