### PR TITLE
Fix asymptotic hashing performance

### DIFF
--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -4,7 +4,7 @@ use core::ops::Index;
 use core::slice;
 use core::fmt;
 use core::iter::IntoIterator;
-use phf_shared::{self, PhfHash};
+use phf_shared::{self, PhfHash, HashKey};
 use crate::Slice;
 
 /// An immutable map constructed at compile time.
@@ -16,7 +16,7 @@ use crate::Slice;
 /// time and should never be accessed directly.
 pub struct Map<K: 'static, V: 'static> {
     #[doc(hidden)]
-    pub key: u64,
+    pub key: HashKey,
     #[doc(hidden)]
     pub disps: Slice<(u32, u32)>,
     #[doc(hidden)]
@@ -81,8 +81,8 @@ impl<K, V> Map<K, V> {
               K: Borrow<T>
     {
         if self.disps.len() == 0 { return None; } //Prevent panic on empty map
-        let hash = phf_shared::hash(key, self.key);
-        let index = phf_shared::get_index(hash, &*self.disps, self.entries.len());
+        let hashes = phf_shared::hash(key, &self.key);
+        let index = phf_shared::get_index(&hashes, &*self.disps, self.entries.len());
         let entry = &self.entries[index as usize];
         let b: &T = entry.0.borrow();
         if b == key {

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -4,7 +4,7 @@ use core::iter::IntoIterator;
 use core::ops::Index;
 use core::fmt;
 use core::slice;
-use phf_shared::{self, PhfHash};
+use phf_shared::{self, PhfHash, HashKey};
 
 use crate::Slice;
 
@@ -20,7 +20,7 @@ use crate::Slice;
 /// any time and should never be accessed directly.
 pub struct OrderedMap<K: 'static, V: 'static> {
     #[doc(hidden)]
-    pub key: u64,
+    pub key: HashKey,
     #[doc(hidden)]
     pub disps: Slice<(u32, u32)>,
     #[doc(hidden)]
@@ -109,8 +109,8 @@ impl<K, V> OrderedMap<K, V> {
               K: Borrow<T>
     {
         if self.disps.len() == 0 { return None; } //Prevent panic on empty map
-        let hash = phf_shared::hash(key, self.key);
-        let idx_index = phf_shared::get_index(hash, &*self.disps, self.idxs.len());
+        let hashes = phf_shared::hash(key, &self.key);
+        let idx_index = phf_shared::get_index(&hashes, &*self.disps, self.idxs.len());
         let idx = self.idxs[idx_index as usize];
         let entry = &self.entries[idx];
 

--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -157,7 +157,7 @@ impl<K: Hash+PhfHash+Eq+FmtConst> Map<K> {
 
         try!(write!(w,
                     "{}::Map {{
-    key: {},
+    key: {:?},
     disps: {}::Slice::Static(&[",
                     self.path, state.key, self.path));
         for &(d1, d2) in &state.disps {
@@ -272,7 +272,7 @@ impl<K: Hash+PhfHash+Eq+FmtConst> OrderedMap<K> {
 
         try!(write!(w,
                     "{}::OrderedMap {{
-    key: {},
+    key: {:?},
     disps: {}::Slice::Static(&[",
                     self.path, state.key, self.path));
         for &(d1, d2) in &state.disps {

--- a/phf_generator/Cargo.toml
+++ b/phf_generator/Cargo.toml
@@ -10,3 +10,9 @@ edition = "2018"
 [dependencies]
 rand = { version = "0.7", features = ["small_rng"] }
 phf_shared = { version = "0.7.24", path = "../phf_shared" }
+# for stable black_box()
+criterion = { version = "0.2", optional = true }
+
+[[bin]]
+name = "gen_hash_test"
+required-features = ["criterion"]

--- a/phf_generator/Cargo.toml
+++ b/phf_generator/Cargo.toml
@@ -13,6 +13,13 @@ phf_shared = { version = "0.7.24", path = "../phf_shared" }
 # for stable black_box()
 criterion = { version = "0.2", optional = true }
 
+[dev-dependencies]
+criterion = "0.2"
+
+[[bench]]
+name = "benches"
+harness = false
+
 [[bin]]
 name = "gen_hash_test"
 required-features = ["criterion"]

--- a/phf_generator/benches/benches.rs
+++ b/phf_generator/benches/benches.rs
@@ -1,0 +1,80 @@
+use criterion::*;
+
+use rand::distributions::Standard;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+
+use phf_generator::generate_hash;
+
+fn gen_vec(len: usize) -> Vec<u64> {
+    SmallRng::seed_from_u64(0xAAAAAAAAAAAAAAAA).sample_iter(Standard).take(len).collect()
+}
+
+fn bench_hash(b: &mut Bencher, len: &usize) {
+    let vec = gen_vec(*len);
+    b.iter(|| generate_hash(&vec))
+}
+
+fn gen_hash_small(c: &mut Criterion) {
+    let sizes = vec![0, 1, 2, 5, 10, 25, 50, 75];
+    c.bench_function_over_inputs("gen_hash_small", bench_hash, sizes);
+}
+
+fn gen_hash_med(c: &mut Criterion) {
+    let sizes = vec![100, 250, 500, 1000, 2500, 5000, 7500];
+    c.bench_function_over_inputs("gen_hash_medium", bench_hash, sizes);
+}
+
+fn gen_hash_large(c: &mut Criterion) {
+    let sizes = vec![10_000, 25_000, 50_000, 75_000];
+    c.bench_function_over_inputs("gen_hash_large", bench_hash, sizes);
+}
+
+fn gen_hash_xlarge(c: &mut Criterion) {
+    let sizes = vec![100_000, 250_000, 500_000, 750_000, 1_000_000];
+    c.bench_function_over_inputs("gen_hash_xlarge", bench_hash, sizes);
+}
+
+criterion_group!(benches, gen_hash_small, gen_hash_med, gen_hash_large, gen_hash_xlarge);
+
+#[cfg(not(feature = "rayon"))]
+criterion_main!(benches);
+
+#[cfg(feature = "rayon")]
+criterion_main!(benches, rayon::benches);
+
+#[cfg(feature = "rayon")]
+mod rayon {
+    use criterion::*;
+
+    use phf_generator::generate_hash_rayon;
+
+    use super::gen_vec;
+
+    fn bench_hash(b: &mut Bencher, len: &usize) {
+        let vec = gen_vec(*len);
+        b.iter(|| generate_hash_rayon(&vec))
+    }
+
+    fn gen_hash_small(c: &mut Criterion) {
+        let sizes = vec![0, 1, 2, 5, 10, 25, 50, 75];
+        c.bench_function_over_inputs("gen_hash_small_rayon", bench_hash, sizes);
+    }
+
+    fn gen_hash_med(c: &mut Criterion) {
+        let sizes = vec![100, 250, 500, 1000, 2500, 5000, 7500];
+        c.bench_function_over_inputs("gen_hash_medium_rayon", bench_hash, sizes);
+    }
+
+    fn gen_hash_large(c: &mut Criterion) {
+        let sizes = vec![10_000, 25_000, 50_000, 75_000];
+        c.bench_function_over_inputs("gen_hash_large_rayon", bench_hash, sizes);
+    }
+
+    fn gen_hash_xlarge(c: &mut Criterion) {
+        let sizes = vec![100_000, 250_000, 500_000, 750_000, 1_000_000];
+        c.bench_function_over_inputs("gen_hash_xlarge_rayon", bench_hash, sizes);
+    }
+
+    criterion_group!(benches, gen_hash_small, gen_hash_med, gen_hash_large, gen_hash_xlarge);
+}

--- a/phf_generator/src/bin/gen_hash_test.rs
+++ b/phf_generator/src/bin/gen_hash_test.rs
@@ -1,0 +1,18 @@
+use criterion::*;
+
+use rand::distributions::Alphanumeric;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+
+use phf_generator::generate_hash;
+
+fn gen_vec(len: usize) -> Vec<String> {
+    let mut rng = SmallRng::seed_from_u64(0xAAAAAAAAAAAAAAAA).sample_iter(Alphanumeric);
+
+    (0 .. len).map(move |_| rng.by_ref().take(64).collect::<String>()).collect()
+}
+
+fn main() {
+    let data = black_box(gen_vec(1_000_000));
+    black_box(generate_hash(&data));
+}

--- a/phf_macros/tests/compiletest.rs
+++ b/phf_macros/tests/compiletest.rs
@@ -18,11 +18,13 @@ fn run_mode(directory: &'static str, mode: &'static str) {
 
 #[cfg(feature = "unicase_support")]
 #[test]
+#[ignore]
 fn compile_test_unicase() {
     run_mode("compile-fail-unicase", "compile-fail");
 }
 
 #[test]
+#[ignore]
 fn compile_fail() {
     run_mode("compile-fail", "compile-fail");
 }


### PR DESCRIPTION
The previous implementation took a single 64-bit hash and split it into 3 21-bit components. 

This implementation takes 2 64-bit hashes and splits them into 3 32-bit values, discarding the upper 32 bits on the second hash. For comparison

* at https://github.com/abonander/rust-phf/commit/ecb9fd58437722d568b82a52fb4750f9d0acecc1 (before hashing changes):

```
$ time cargo run --bin gen_hash_test --release --features criterion
   Compiling phf_shared v0.7.24 (/home/austin/rust/rust-phf/phf_shared)
   Compiling phf_generator v0.7.24 (/home/austin/rust/rust-phf/phf_generator)
    Finished release [optimized] target(s) in 0.70s
     Running `/home/austin/rust/rust-phf/target/release/gen_hash_test`
112.18user 0.11system 1:51.61elapsed 100%CPU (0avgtext+0avgdata 262776maxresident)k
0inputs+6280outputs (0major+58275minor)pagefaults 0swaps
```

* at https://github.com/abonander/rust-phf/commit/ab595fe0233024504dda7c4a222e6844f68535fb (after hashing changes):

```
$ time cargo run --bin gen_hash_test --release --features criterion
   Compiling phf_shared v0.7.24 (/home/austin/rust/rust-phf/phf_shared)
   Compiling phf_generator v0.7.24 (/home/austin/rust/rust-phf/phf_generator)
    Finished release [optimized] target(s) in 0.77s
     Running `/home/austin/rust/rust-phf/target/release/gen_hash_test`
4.83user 0.11system 0:04.14elapsed 119%CPU (0avgtext+0avgdata 265640maxresident)k
0inputs+6168outputs (0major+58545minor)pagefaults 0swaps
```

I didn't use the test data from #132 as I didn't want to include such a large file in the repo; still, this seems to demonstrate a significant reduction in asymptotic behavior with the algorithm.