### PR TITLE
replace usage of `std::borrow::Borrow` with new `PhfBorrow` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Restore the `unicase_support` feature for `phf_macros`
 * Allow using the owned `String` type for `phf` dynamic code generation
 * Add back `OrderedMap` and `OrderedSet`
+* (**breaking change**) Use `PhfBorrow` trait instead of `std::borrow::Borrow`
 
 ## 0.8.0
 

--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -1,10 +1,9 @@
 //! An immutable map constructed at compile time.
-use core::borrow::Borrow;
 use core::ops::Index;
 use core::slice;
 use core::fmt;
 use core::iter::IntoIterator;
-use phf_shared::{self, PhfHash, HashKey};
+use phf_shared::{self, PhfHash, PhfBorrow, HashKey};
 use crate::Slice;
 
 /// An immutable map constructed at compile time.
@@ -29,7 +28,7 @@ impl<K, V> fmt::Debug for Map<K, V> where K: fmt::Debug, V: fmt::Debug {
     }
 }
 
-impl<'a, K, V, T: ?Sized> Index<&'a T> for Map<K, V> where T: Eq + PhfHash, K: Borrow<T> {
+impl<'a, K, V, T: ?Sized> Index<&'a T> for Map<K, V> where T: Eq + PhfHash, K: PhfBorrow<T> {
     type Output = V;
 
     fn index(&self, k: &'a T) -> &V {
@@ -51,7 +50,7 @@ impl<K, V> Map<K, V> {
     /// Determines if `key` is in the `Map`.
     pub fn contains_key<T: ?Sized>(&self, key: &T) -> bool
         where T: Eq + PhfHash,
-              K: Borrow<T>
+              K: PhfBorrow<T>
     {
         self.get(key).is_some()
     }
@@ -59,7 +58,7 @@ impl<K, V> Map<K, V> {
     /// Returns a reference to the value that `key` maps to.
     pub fn get<T: ?Sized>(&self, key: &T) -> Option<&V>
         where T: Eq + PhfHash,
-              K: Borrow<T>
+              K: PhfBorrow<T>
     {
         self.get_entry(key).map(|e| e.1)
     }
@@ -70,7 +69,7 @@ impl<K, V> Map<K, V> {
     /// This can be useful for interning schemes.
     pub fn get_key<T: ?Sized>(&self, key: &T) -> Option<&K>
         where T: Eq + PhfHash,
-              K: Borrow<T>
+              K: PhfBorrow<T>
     {
         self.get_entry(key).map(|e| e.0)
     }
@@ -78,7 +77,7 @@ impl<K, V> Map<K, V> {
     /// Like `get`, but returns both the key and the value.
     pub fn get_entry<T: ?Sized>(&self, key: &T) -> Option<(&K, &V)>
         where T: Eq + PhfHash,
-              K: Borrow<T>
+              K: PhfBorrow<T>
     {
         if self.disps.len() == 0 { return None; } //Prevent panic on empty map
         let hashes = phf_shared::hash(key, &self.key);

--- a/phf/src/set.rs
+++ b/phf/src/set.rs
@@ -1,9 +1,10 @@
 //! An immutable set constructed at compile time.
-use core::borrow::Borrow;
 use core::iter::IntoIterator;
 use core::fmt;
 
-use crate::{map, Map, PhfHash};
+use phf_shared::{PhfBorrow, PhfHash};
+
+use crate::{map, Map};
 
 /// An immutable set constructed at compile time.
 ///
@@ -40,7 +41,7 @@ impl<T> Set<T> {
     /// This can be useful for interning schemes.
     pub fn get_key<U: ?Sized>(&self, key: &U) -> Option<&T>
         where U: Eq + PhfHash,
-              T: Borrow<U>
+              T: PhfBorrow<U>
     {
         self.map.get_key(key)
     }
@@ -48,7 +49,7 @@ impl<T> Set<T> {
     /// Returns true if `value` is in the `Set`.
     pub fn contains<U: ?Sized>(&self, value: &U) -> bool
         where U: Eq + PhfHash,
-              T: Borrow<U>
+              T: PhfBorrow<U>
     {
         self.map.contains_key(value)
     }
@@ -61,7 +62,7 @@ impl<T> Set<T> {
     }
 }
 
-impl<T> Set<T> where T: Eq + PhfHash {
+impl<T> Set<T> where T: Eq + PhfHash + PhfBorrow<T> {
     /// Returns true if `other` shares no elements with `self`.
     pub fn is_disjoint(&self, other: &Set<T>) -> bool {
         !self.iter().any(|value| other.contains(value))

--- a/phf_codegen/test/src/lib.rs
+++ b/phf_codegen/test/src/lib.rs
@@ -51,6 +51,14 @@ mod test {
         assert_eq!("a", UNICASE_MAP[&UniCase::new("abc")]);
         assert_eq!("b", UNICASE_MAP[&UniCase::new("DEf")]);
         assert!(!UNICASE_MAP.contains_key(&UniCase::new("XyZ")));
+
+        // allow lookup with non-static slices
+        let local_str_1 = "AbC".to_string();
+        let local_str_2 = "abc".to_string();
+        let local_str_3 = "DEf".to_string();
+        assert_eq!("a", UNICASE_MAP[&UniCase::new(&*local_str_1)]);
+        assert_eq!("a", UNICASE_MAP[&UniCase::new(&*local_str_2)]);
+        assert_eq!("b", UNICASE_MAP[&UniCase::new(&*local_str_3)]);
     }
 
     #[test]


### PR DESCRIPTION
Motivation is provided in the doc comments for `PhfBorrow` as well as #169.

All the tests pass unchanged so there should be few to no breaking changes when using the provided key types; custom types will of course need to manually implement `PhfBorrow`. We could maybe provide a macro or a derive in `phf_macros`?

Also deletes `phf_builder/` cause I screwed that up when I rebased #171; when fixing the merge conflicts I somehow set it to delete the files' contents but not remove the files.

Closes #169 

cc @sfackler 