### PR TITLE
chore: upgrade syn/proc-macro

### DIFF
--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/sfackler/rust-phf"
 proc-macro = true
 
 [dependencies]
-syn = { version = "0.15", features = ["full"] }
-quote = "0.6"
-proc-macro2 = "0.4"
+syn = { version = "1", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"
 proc-macro-hack = "0.5.4"
 
 phf_generator = { version = "0.7.24", path = "../phf_generator" }


### PR DESCRIPTION
Fixes #178.

The way integers work has changed; we now get a `&str` for the digits, and a `&str` for the suffix.

We can parse the digits like before, but have to be a bit more cunning with target types. See the comment. There is existing test coverage for these boundaries.

I've hardcoded all the suffixes as string literals, as they are barely used. Maybe someone would prefer `const SUFFIX_U8: &str = "u8";`?

I have not tested the integration with `proc-macro-hack`.