### PR TITLE
Updated the `#[doc(html_root_url)]` to use 0.8 path instead of 0.7.

### DIFF
--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! (Alternatively, you can use the phf_codegen crate to generate PHF datatypes
 //! in a build script)
-#![doc(html_root_url="https://docs.rs/phf/0.7")]
+#![doc(html_root_url="https://docs.rs/phf/0.8")]
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -131,7 +131,7 @@
 //! builder.entry("world", "2");
 //! // ...
 //! ```
-#![doc(html_root_url = "https://docs.rs/phf_codegen/0.7")]
+#![doc(html_root_url = "https://docs.rs/phf_codegen/0.8")]
 
 use phf_shared::{PhfHash, FmtConst};
 use std::collections::HashSet;

--- a/phf_generator/src/lib.rs
+++ b/phf_generator/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url="https://docs.rs/phf_generator/0.7")]
+#![doc(html_root_url="https://docs.rs/phf_generator/0.8")]
 use phf_shared::{PhfHash, HashKey};
 use rand::{SeedableRng, Rng};
 use rand::distributions::Standard;

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/phf_shared/0.7")]
+#![doc(html_root_url = "https://docs.rs/phf_shared/0.8")]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
This updates the `phf` crates to have their `#[doc(html_root_url)]` to use 0.8 to match the version of the crates.