### PR TITLE
Support String as FmtConst and tuple keys

### DIFF
--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! (Alternatively, you can use the phf_codegen crate to generate PHF datatypes
 //! in a build script)
-#![doc(html_root_url="https://docs.rs/phf/0.7")]
+#![doc(html_root_url = "https://docs.rs/phf/0.7")]
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -64,7 +64,7 @@ extern crate std as core;
 /// }
 /// ```
 #[::proc_macro_hack::proc_macro_hack]
-pub use phf_macros:: phf_map;
+pub use phf_macros::phf_map;
 
 #[cfg(feature = "macros")]
 /// Macro to create a `static` (compile-time) [`Set`].
@@ -91,11 +91,11 @@ pub use phf_macros::phf_set;
 
 use core::ops::Deref;
 
-pub use phf_shared::PhfHash;
 #[doc(inline)]
 pub use self::map::Map;
 #[doc(inline)]
 pub use self::set::Set;
+pub use phf_shared::PhfHash;
 
 pub mod map;
 pub mod set;

--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -1,11 +1,11 @@
 //! An immutable map constructed at compile time.
+use crate::Slice;
 use core::borrow::Borrow;
-use core::ops::Index;
-use core::slice;
 use core::fmt;
 use core::iter::IntoIterator;
-use phf_shared::{self, PhfHash, HashKey};
-use crate::Slice;
+use core::ops::Index;
+use core::slice;
+use phf_shared::{self, HashKey, PhfHash};
 
 /// An immutable map constructed at compile time.
 ///
@@ -23,13 +23,21 @@ pub struct Map<K: 'static, V: 'static> {
     pub entries: Slice<(K, V)>,
 }
 
-impl<K, V> fmt::Debug for Map<K, V> where K: fmt::Debug, V: fmt::Debug {
+impl<K, V> fmt::Debug for Map<K, V>
+where
+    K: fmt::Debug,
+    V: fmt::Debug,
+{
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_map().entries(self.entries()).finish()
     }
 }
 
-impl<'a, K, V, T: ?Sized> Index<&'a T> for Map<K, V> where T: Eq + PhfHash, K: Borrow<T> {
+impl<'a, K, V, T: ?Sized> Index<&'a T> for Map<K, V>
+where
+    T: Eq + PhfHash,
+    K: Borrow<T>,
+{
     type Output = V;
 
     fn index(&self, k: &'a T) -> &V {
@@ -50,16 +58,18 @@ impl<K, V> Map<K, V> {
 
     /// Determines if `key` is in the `Map`.
     pub fn contains_key<T: ?Sized>(&self, key: &T) -> bool
-        where T: Eq + PhfHash,
-              K: Borrow<T>
+    where
+        T: Eq + PhfHash,
+        K: Borrow<T>,
     {
         self.get(key).is_some()
     }
 
     /// Returns a reference to the value that `key` maps to.
     pub fn get<T: ?Sized>(&self, key: &T) -> Option<&V>
-        where T: Eq + PhfHash,
-              K: Borrow<T>
+    where
+        T: Eq + PhfHash,
+        K: Borrow<T>,
     {
         self.get_entry(key).map(|e| e.1)
     }
@@ -69,18 +79,22 @@ impl<K, V> Map<K, V> {
     ///
     /// This can be useful for interning schemes.
     pub fn get_key<T: ?Sized>(&self, key: &T) -> Option<&K>
-        where T: Eq + PhfHash,
-              K: Borrow<T>
+    where
+        T: Eq + PhfHash,
+        K: Borrow<T>,
     {
         self.get_entry(key).map(|e| e.0)
     }
 
     /// Like `get`, but returns both the key and the value.
     pub fn get_entry<T: ?Sized>(&self, key: &T) -> Option<(&K, &V)>
-        where T: Eq + PhfHash,
-              K: Borrow<T>
+    where
+        T: Eq + PhfHash,
+        K: Borrow<T>,
     {
-        if self.disps.len() == 0 { return None; } //Prevent panic on empty map
+        if self.disps.len() == 0 {
+            return None;
+        } //Prevent panic on empty map
         let hashes = phf_shared::hash(key, &self.key);
         let index = phf_shared::get_index(&hashes, &*self.disps, self.entries.len());
         let entry = &self.entries[index as usize];
@@ -96,21 +110,27 @@ impl<K, V> Map<K, V> {
     ///
     /// Entries are returned in an arbitrary but fixed order.
     pub fn entries<'a>(&'a self) -> Entries<'a, K, V> {
-        Entries { iter: self.entries.iter() }
+        Entries {
+            iter: self.entries.iter(),
+        }
     }
 
     /// Returns an iterator over the keys in the map.
     ///
     /// Keys are returned in an arbitrary but fixed order.
     pub fn keys<'a>(&'a self) -> Keys<'a, K, V> {
-        Keys { iter: self.entries() }
+        Keys {
+            iter: self.entries(),
+        }
     }
 
     /// Returns an iterator over the values in the map.
     ///
     /// Values are returned in an arbitrary but fixed order.
     pub fn values<'a>(&'a self) -> Values<'a, K, V> {
-        Values { iter: self.entries() }
+        Values {
+            iter: self.entries(),
+        }
     }
 }
 

--- a/phf/src/set.rs
+++ b/phf/src/set.rs
@@ -1,7 +1,7 @@
 //! An immutable set constructed at compile time.
 use core::borrow::Borrow;
-use core::iter::IntoIterator;
 use core::fmt;
+use core::iter::IntoIterator;
 
 use crate::{map, Map, PhfHash};
 
@@ -17,7 +17,10 @@ pub struct Set<T: 'static> {
     pub map: Map<T, ()>,
 }
 
-impl<T> fmt::Debug for Set<T> where T: fmt::Debug {
+impl<T> fmt::Debug for Set<T>
+where
+    T: fmt::Debug,
+{
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_set().entries(self).finish()
     }
@@ -39,16 +42,18 @@ impl<T> Set<T> {
     ///
     /// This can be useful for interning schemes.
     pub fn get_key<U: ?Sized>(&self, key: &U) -> Option<&T>
-        where U: Eq + PhfHash,
-              T: Borrow<U>
+    where
+        U: Eq + PhfHash,
+        T: Borrow<U>,
     {
         self.map.get_key(key)
     }
 
     /// Returns true if `value` is in the `Set`.
     pub fn contains<U: ?Sized>(&self, value: &U) -> bool
-        where U: Eq + PhfHash,
-              T: Borrow<U>
+    where
+        U: Eq + PhfHash,
+        T: Borrow<U>,
     {
         self.map.contains_key(value)
     }
@@ -57,11 +62,16 @@ impl<T> Set<T> {
     ///
     /// Values are returned in an arbitrary but fixed order.
     pub fn iter<'a>(&'a self) -> Iter<'a, T> {
-        Iter { iter: self.map.keys() }
+        Iter {
+            iter: self.map.keys(),
+        }
     }
 }
 
-impl<T> Set<T> where T: Eq + PhfHash {
+impl<T> Set<T>
+where
+    T: Eq + PhfHash,
+{
     /// Returns true if `other` shares no elements with `self`.
     pub fn is_disjoint(&self, other: &Set<T>) -> bool {
         !self.iter().any(|value| other.contains(value))

--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -133,7 +133,7 @@
 //! ```
 #![doc(html_root_url = "https://docs.rs/phf_codegen/0.7")]
 
-use phf_shared::{PhfHash, FmtConst};
+use phf_shared::{FmtConst, PhfHash};
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
@@ -221,45 +221,54 @@ pub struct DisplayMap<'a, K> {
     state: HashState,
     keys: &'a [K],
     values: &'a [String],
-
 }
 
 impl<'a, K: FmtConst + 'a> fmt::Display for DisplayMap<'a, K> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // funky formatting here for nice output
-        write!(f,
-               "{}::Map {{
+        write!(
+            f,
+            "{}::Map {{
     key: {:?},
     disps: {}::Slice::Static(&[",
-               self.path, self.state.key, self.path)?;
+            self.path, self.state.key, self.path
+        )?;
 
         // write map displacements
         for &(d1, d2) in &self.state.disps {
-            write!(f,
-                   "
+            write!(
+                f,
+                "
         ({}, {}),",
-                   d1,
-                   d2)?;
+                d1, d2
+            )?;
         }
 
-        write!(f,
-               "
+        write!(
+            f,
+            "
     ]),
-    entries: {}::Slice::Static(&[", self.path)?;
+    entries: {}::Slice::Static(&[",
+            self.path
+        )?;
 
         // write map entries
         for &idx in &self.state.map {
-            write!(f,
-                   "
+            write!(
+                f,
+                "
         ({}, {}),",
-                   Delegate(&self.keys[idx]),
-                   &self.values[idx])?;
+                Delegate(&self.keys[idx]),
+                &self.values[idx]
+            )?;
         }
 
-        write!(f,
-               "
+        write!(
+            f,
+            "
     ]),
-}}")
+}}"
+        )
     }
 }
 
@@ -271,9 +280,7 @@ pub struct Set<T> {
 impl<T: Hash + PhfHash + Eq + FmtConst> Set<T> {
     /// Constructs a new `phf::Set` builder.
     pub fn new() -> Set<T> {
-        Set {
-            map: Map::new(),
-        }
+        Set { map: Map::new() }
     }
 
     /// Set the path to the `phf` crate from the global namespace
@@ -296,7 +303,7 @@ impl<T: Hash + PhfHash + Eq + FmtConst> Set<T> {
     /// Panics if there are any duplicate keys.
     pub fn build(&self) -> DisplaySet<T> {
         DisplaySet {
-            inner: self.map.build()
+            inner: self.map.build(),
         }
     }
 }

--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -52,23 +52,31 @@ fn main() -> io::Result<()> {
     )?;
 
     //u32 is used here purely for a type that impls `Hash+PhfHash+Eq+fmt::Debug`, but is not required for the empty test itself
-    writeln!(&mut file,
-             "static EMPTY: ::phf::Map<u32, u32> = \n{};",
-             phf_codegen::Map::<u32>::new().build())?;
+    writeln!(
+        &mut file,
+        "static EMPTY: ::phf::Map<u32, u32> = \n{};",
+        phf_codegen::Map::<u32>::new().build()
+    )?;
 
-    writeln!(&mut file, "static ARRAY_KEYS: ::phf::Map<[u8; 3], u32> = \n{};",
-             phf_codegen::Map::<[u8; 3]>::new()
-                 .entry(*b"foo", "0")
-                 .entry(*b"bar", "1")
-                 .entry(*b"baz", "2")
-                 .build())?;
+    writeln!(
+        &mut file,
+        "static ARRAY_KEYS: ::phf::Map<[u8; 3], u32> = \n{};",
+        phf_codegen::Map::<[u8; 3]>::new()
+            .entry(*b"foo", "0")
+            .entry(*b"bar", "1")
+            .entry(*b"baz", "2")
+            .build()
+    )?;
 
     // key type required here as it will infer `&'static [u8; 3]` instead
-    writeln!(&mut file, "static BYTE_STR_KEYS: ::phf::Map<&[u8], u32> = \n{};",
-             phf_codegen::Map::<&[u8]>::new()
-                 .entry(b"foo", "0")
-                 .entry(b"bar", "1")
-                 .entry(b"baz", "2")
-                 .entry(b"quux", "3")
-                 .build())
+    writeln!(
+        &mut file,
+        "static BYTE_STR_KEYS: ::phf::Map<&[u8], u32> = \n{};",
+        phf_codegen::Map::<&[u8]>::new()
+            .entry(b"foo", "0")
+            .entry(b"bar", "1")
+            .entry(b"baz", "2")
+            .entry(b"quux", "3")
+            .build()
+    )
 }

--- a/phf_codegen/test/src/lib.rs
+++ b/phf_codegen/test/src/lib.rs
@@ -51,7 +51,7 @@ mod test {
         assert_eq!(3, BYTE_STR_KEYS[&b"quux"[..]]);
     }
 
-     #[test]
+    #[test]
     fn empty_map() {
         assert_eq!(None, EMPTY.get(&1));
     }

--- a/phf_generator/benches/benches.rs
+++ b/phf_generator/benches/benches.rs
@@ -7,7 +7,10 @@ use rand::{Rng, SeedableRng};
 use phf_generator::generate_hash;
 
 fn gen_vec(len: usize) -> Vec<u64> {
-    SmallRng::seed_from_u64(0xAAAAAAAAAAAAAAAA).sample_iter(Standard).take(len).collect()
+    SmallRng::seed_from_u64(0xAAAAAAAAAAAAAAAA)
+        .sample_iter(Standard)
+        .take(len)
+        .collect()
 }
 
 fn bench_hash(b: &mut Bencher, len: &usize) {
@@ -35,7 +38,13 @@ fn gen_hash_xlarge(c: &mut Criterion) {
     c.bench_function_over_inputs("gen_hash_xlarge", bench_hash, sizes);
 }
 
-criterion_group!(benches, gen_hash_small, gen_hash_med, gen_hash_large, gen_hash_xlarge);
+criterion_group!(
+    benches,
+    gen_hash_small,
+    gen_hash_med,
+    gen_hash_large,
+    gen_hash_xlarge
+);
 
 #[cfg(not(feature = "rayon"))]
 criterion_main!(benches);
@@ -76,5 +85,11 @@ mod rayon {
         c.bench_function_over_inputs("gen_hash_xlarge_rayon", bench_hash, sizes);
     }
 
-    criterion_group!(benches, gen_hash_small, gen_hash_med, gen_hash_large, gen_hash_xlarge);
+    criterion_group!(
+        benches,
+        gen_hash_small,
+        gen_hash_med,
+        gen_hash_large,
+        gen_hash_xlarge
+    );
 }

--- a/phf_generator/src/bin/gen_hash_test.rs
+++ b/phf_generator/src/bin/gen_hash_test.rs
@@ -9,7 +9,9 @@ use phf_generator::generate_hash;
 fn gen_vec(len: usize) -> Vec<String> {
     let mut rng = SmallRng::seed_from_u64(0xAAAAAAAAAAAAAAAA).sample_iter(Alphanumeric);
 
-    (0 .. len).map(move |_| rng.by_ref().take(64).collect::<String>()).collect()
+    (0..len)
+        .map(move |_| rng.by_ref().take(64).collect::<String>())
+        .collect()
 }
 
 fn main() {

--- a/phf_generator/src/lib.rs
+++ b/phf_generator/src/lib.rs
@@ -1,8 +1,8 @@
-#![doc(html_root_url="https://docs.rs/phf_generator/0.7")]
-use phf_shared::{PhfHash, HashKey};
-use rand::{SeedableRng, Rng};
+#![doc(html_root_url = "https://docs.rs/phf_generator/0.7")]
+use phf_shared::{HashKey, PhfHash};
 use rand::distributions::Standard;
 use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 const DEFAULT_LAMBDA: usize = 5;
 
@@ -27,20 +27,23 @@ fn try_generate_hash<H: PhfHash>(entries: &[H], key: HashKey) -> Option<HashStat
         keys: Vec<usize>,
     }
 
-    let hashes: Vec<_> = entries.iter().map(|entry| phf_shared::hash(entry, &key)).collect();
+    let hashes: Vec<_> = entries
+        .iter()
+        .map(|entry| phf_shared::hash(entry, &key))
+        .collect();
 
     let buckets_len = (hashes.len() + DEFAULT_LAMBDA - 1) / DEFAULT_LAMBDA;
     let mut buckets = (0..buckets_len)
-                          .map(|i| {
-                              Bucket {
-                                  idx: i,
-                                  keys: vec![],
-                              }
-                          })
-                          .collect::<Vec<_>>();
+        .map(|i| Bucket {
+            idx: i,
+            keys: vec![],
+        })
+        .collect::<Vec<_>>();
 
     for (i, hash) in hashes.iter().enumerate() {
-        buckets[(hash.g % (buckets_len as u32)) as usize].keys.push(i);
+        buckets[(hash.g % (buckets_len as u32)) as usize]
+            .keys
+            .push(i);
     }
 
     // Sort descending
@@ -72,8 +75,8 @@ fn try_generate_hash<H: PhfHash>(entries: &[H], key: HashKey) -> Option<HashStat
                 generation += 1;
 
                 for &key in &bucket.keys {
-                    let idx = (phf_shared::displace(hashes[key].f1, hashes[key].f2, d1, d2) %
-                               (table_len as u32)) as usize;
+                    let idx = (phf_shared::displace(hashes[key].f1, hashes[key].f2, d1, d2)
+                        % (table_len as u32)) as usize;
                     if map[idx].is_some() || try_map[idx] == generation {
                         continue 'disps;
                     }

--- a/phf_macros/benches/bench.rs
+++ b/phf_macros/benches/bench.rs
@@ -3,9 +3,9 @@
 extern crate test;
 
 mod map {
+    use phf::phf_map;
     use std::collections::{BTreeMap, HashMap};
     use test::Bencher;
-    use phf::phf_map;
 
     macro_rules! map_and_match {
         ($map:ident, $f:ident, $($key:expr => $value:expr,)+) => {
@@ -107,7 +107,6 @@ mod map {
             assert_eq!(map.get("potato"), None);
         })
     }
-
 
     #[bench]
     fn bench_hashmap_none(b: &mut Bencher) {

--- a/phf_macros/src/lib.rs
+++ b/phf_macros/src/lib.rs
@@ -30,8 +30,8 @@ enum ParsedKey {
 
 impl PhfHash for ParsedKey {
     fn phf_hash<H>(&self, state: &mut H)
-        where
-            H: Hasher,
+    where
+        H: Hasher,
     {
         match self {
             ParsedKey::Str(s) => s.phf_hash(state),
@@ -128,8 +128,8 @@ struct Key {
 
 impl PhfHash for Key {
     fn phf_hash<H>(&self, state: &mut H)
-        where
-            H: Hasher,
+    where
+        H: Hasher,
     {
         self.parsed.phf_hash(state)
     }
@@ -152,8 +152,8 @@ struct Entry {
 
 impl PhfHash for Entry {
     fn phf_hash<H>(&self, state: &mut H)
-        where
-            H: Hasher,
+    where
+        H: Hasher,
     {
         self.key.phf_hash(state)
     }

--- a/phf_macros/tests/test.rs
+++ b/phf_macros/tests/test.rs
@@ -1,6 +1,6 @@
 mod map {
-    use std::collections::{HashMap, HashSet};
     use phf::phf_map;
+    use std::collections::{HashMap, HashSet};
 
     #[allow(dead_code)]
     static TRAILING_COMMA: phf::Map<&'static str, isize> = phf_map!(
@@ -35,7 +35,10 @@ mod map {
             "foo" => 10,
             "bar" => 11,
         );
-        let hash = MAP.entries().map(|(&k, &v)| (k, v)).collect::<HashMap<_, isize>>();
+        let hash = MAP
+            .entries()
+            .map(|(&k, &v)| (k, v))
+            .collect::<HashMap<_, isize>>();
         assert!(Some(&10) == hash.get(&("foo")));
         assert!(Some(&11) == hash.get(&("bar")));
         assert_eq!(2, hash.len());
@@ -265,8 +268,8 @@ mod map {
 }
 
 mod set {
-    use std::collections::HashSet;
     use phf::phf_set;
+    use std::collections::HashSet;
 
     #[allow(dead_code)]
     static TRAILING_COMMA: phf::Set<&'static str> = phf_set! {

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -10,7 +10,7 @@ extern crate siphasher;
 extern crate unicase;
 
 use core::fmt;
-use core::hash::{Hasher, Hash};
+use core::hash::{Hash, Hasher};
 use core::num::Wrapping;
 use siphasher::sip128::{Hash128, Hasher128, SipHasher13};
 
@@ -37,7 +37,10 @@ pub fn hash<T: ?Sized + PhfHash>(x: &T, key: &HashKey) -> Hashes {
     let mut hasher = SipHasher13::new_with_keys(0, *key);
     x.phf_hash(&mut hasher);
 
-    let Hash128 { h1: lower, h2: upper} = hasher.finish128();
+    let Hash128 {
+        h1: lower,
+        h2: upper,
+    } = hasher.finish128();
 
     Hashes {
         g: (lower >> 32) as u32,
@@ -69,7 +72,8 @@ pub trait PhfHash {
 
     /// Feeds a slice of this type into the state provided.
     fn phf_hash_slice<H: Hasher>(data: &[Self], state: &mut H)
-        where Self: Sized
+    where
+        Self: Sized,
     {
         for piece in data {
             piece.phf_hash(state);
@@ -177,7 +181,9 @@ impl FmtConst for [u8] {
 
 #[cfg(feature = "unicase")]
 impl<S> PhfHash for unicase::UniCase<S>
-    where unicase::UniCase<S>: Hash {
+where
+    unicase::UniCase<S>: Hash,
+{
     #[inline]
     fn phf_hash<H: Hasher>(&self, state: &mut H) {
         self.hash(state)
@@ -185,7 +191,10 @@ impl<S> PhfHash for unicase::UniCase<S>
 }
 
 #[cfg(feature = "unicase")]
-impl<S> FmtConst for unicase::UniCase<S> where S: AsRef<str> {
+impl<S> FmtConst for unicase::UniCase<S>
+where
+    S: AsRef<str>,
+{
     fn fmt_const(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.is_ascii() {
             f.write_str("UniCase::ascii(")?;

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -98,6 +98,7 @@ macro_rules! delegate_debug (
 );
 
 delegate_debug!(String);
+delegate_debug!((String, String));
 delegate_debug!(str);
 delegate_debug!(char);
 delegate_debug!(u8);
@@ -125,6 +126,18 @@ impl PhfHash for Vec<u8> {
     #[inline]
     fn phf_hash<H: Hasher>(&self, state: &mut H) {
         (**self).phf_hash(state)
+    }
+}
+
+impl<T, U> PhfHash for (T, U)
+where
+    T: PhfHash,
+    U: PhfHash,
+{
+    #[inline]
+    fn phf_hash<H: Hasher>(&self, state: &mut H) {
+        (self.0).phf_hash(state);
+        (self.1).phf_hash(state);
     }
 }
 

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -97,6 +97,7 @@ macro_rules! delegate_debug (
     }
 );
 
+delegate_debug!(String);
 delegate_debug!(str);
 delegate_debug!(char);
 delegate_debug!(u8);


### PR DESCRIPTION
Would these changes make sense? Do we need any extra tests for this?

Threw in a formatting commit because I have the IDE set to format by default -- let me know if you want me to scratch that.

I was also surprised that the `phf_codegen::Map::entry()` method takes the value by reference and then immediately calls `to_owned()` on it. Presumably it would be more transparent in this case to just take a `String` argument?