### PR TITLE
Allow using the owned `String` type for `phf` dynamic code generation.

### DIFF
--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -112,6 +112,9 @@ delegate_debug!(i128);
 delegate_debug!(bool);
 
 #[cfg(feature = "std")]
+delegate_debug!(String);
+
+#[cfg(feature = "std")]
 impl PhfHash for String {
     #[inline]
     fn phf_hash<H: Hasher>(&self, state: &mut H) {


### PR DESCRIPTION
In version 0.7 of `phf` the owned `String` type could be used but with
changes in 0.8 this is no longer possible without this implementation of
`FmtConst` for `String`.

This is a minimal change of #185, as that pull request is remaining
opened with outstanding comments.