### PR TITLE
Update to rand v0.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   stable:
     docker:
-      - image: rust:1.32.0-slim
+      - image: rust:1.36.0-slim
     environment:
       RUSTFLAGS: -D warnings
     steps:

--- a/phf_generator/Cargo.toml
+++ b/phf_generator/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/sfackler/rust-phf"
 edition = "2018"
 
 [dependencies]
-rand = { version = "0.7", features = ["small_rng"] }
+rand = { version = "0.8", features = ["small_rng"] }
 phf_shared = { version = "0.8.0", path = "../phf_shared" }
 # for stable black_box()
 criterion = { version = "0.3", optional = true }

--- a/phf_macros/tests/compile-fail-unicase/equivalent-keys.stderr
+++ b/phf_macros/tests/compile-fail-unicase/equivalent-keys.stderr
@@ -3,3 +3,5 @@ error: unsupported key expression
   |
 5 |     UniCase("FOO") => 42, //~ NOTE one occurrence here
   |     ^^^^^^^^^^^^^^
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/phf_macros/tests/compile-fail/bad-syntax.stderr
+++ b/phf_macros/tests/compile-fail/bad-syntax.stderr
@@ -3,3 +3,5 @@ error: expected identifier
   |
 5 |     => //~ ERROR expected identifier
   |     ^^
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Update to the latest version of the rand crate. This also requires
bumping the MSRV to 1.36.0.

Resubmission of #200, closes #200