### PR TITLE
Add back ordered_map, ordered_set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix some crates' build on `no_std`
 * Restore the `unicase_support` feature for `phf_macros`
 * Allow using the owned `String` type for `phf` dynamic code generation
+* Add back `OrderedMap` and `OrderedSet`
 
 ## 0.8.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
 
 [patch.crates-io]
 phf = { path = "phf" }
+phf_codegen = { path = "./phf_codegen" }
 phf_generator = { path = "./phf_generator" }
 phf_macros = { path = "./phf_macros" }
 phf_shared = { path = "./phf_shared" }

--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -66,6 +66,13 @@ extern crate std as core;
 pub use phf_macros:: phf_map;
 
 #[cfg(feature = "macros")]
+/// Macro to create a `static` (compile-time) [`OrderedMap`].
+///
+/// Requires the `"macros"` feature. Same usage as [`phf_map`]`!`.
+#[::proc_macro_hack::proc_macro_hack]
+pub use phf_macros::phf_ordered_map;
+
+#[cfg(feature = "macros")]
 /// Macro to create a `static` (compile-time) [`Set`].
 ///
 /// Requires the `"macros"` feature.
@@ -88,6 +95,14 @@ pub use phf_macros:: phf_map;
 #[::proc_macro_hack::proc_macro_hack]
 pub use phf_macros::phf_set;
 
+#[cfg(feature = "macros")]
+/// Macro to create a `static` (compile-time) [`OrderedSet`].
+///
+/// Requires the `"macros"` feature. Same usage as [`phf_set`]`!`.
+#[::proc_macro_hack::proc_macro_hack]
+pub use phf_macros::phf_ordered_set;
+
+
 use core::ops::Deref;
 
 pub use phf_shared::PhfHash;
@@ -95,9 +110,15 @@ pub use phf_shared::PhfHash;
 pub use self::map::Map;
 #[doc(inline)]
 pub use self::set::Set;
+#[doc(inline)]
+pub use self::ordered_map::OrderedMap;
+#[doc(inline)]
+pub use self::ordered_set::OrderedSet;
 
 pub mod map;
 pub mod set;
+pub mod ordered_map;
+pub mod ordered_set;
 
 // WARNING: this is not considered part of phf's public API and is subject to
 // change at any time.

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -1,0 +1,229 @@
+//! An order-preserving immutable map constructed at compile time.
+use core::borrow::Borrow;
+use core::iter::IntoIterator;
+use core::ops::Index;
+use core::fmt;
+use core::slice;
+use phf_shared::{self, PhfHash, HashKey};
+
+use crate::Slice;
+
+/// An order-preserving immutable map constructed at compile time.
+///
+/// Unlike a `Map`, iteration order is guaranteed to match the definition
+/// order.
+///
+/// ## Note
+///
+/// The fields of this struct are public so that they may be initialized by the
+/// `phf_ordered_map!` macro and code generation. They are subject to change at
+/// any time and should never be accessed directly.
+pub struct OrderedMap<K: 'static, V: 'static> {
+    #[doc(hidden)]
+    pub key: HashKey,
+    #[doc(hidden)]
+    pub disps: Slice<(u32, u32)>,
+    #[doc(hidden)]
+    pub idxs: Slice<usize>,
+    #[doc(hidden)]
+    pub entries: Slice<(K, V)>,
+}
+
+impl<K, V> fmt::Debug for OrderedMap<K, V> where K: fmt::Debug, V: fmt::Debug {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_map().entries(self.entries()).finish()
+    }
+}
+
+impl<'a, K, V, T: ?Sized> Index<&'a T> for OrderedMap<K, V> where T: Eq + PhfHash, K: Borrow<T> {
+    type Output = V;
+
+    fn index(&self, k: &'a T) -> &V {
+        self.get(k).expect("invalid key")
+    }
+}
+
+impl<K, V> OrderedMap<K, V> {
+    /// Returns the number of entries in the `Map`.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns true if the `Map` is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns a reference to the value that `key` maps to.
+    pub fn get<T: ?Sized>(&self, key: &T) -> Option<&V>
+        where T: Eq + PhfHash,
+              K: Borrow<T>
+    {
+        self.get_entry(key).map(|e| e.1)
+    }
+
+    /// Returns a reference to the map's internal static instance of the given
+    /// key.
+    ///
+    /// This can be useful for interning schemes.
+    pub fn get_key<T: ?Sized>(&self, key: &T) -> Option<&K>
+        where T: Eq + PhfHash,
+              K: Borrow<T>
+    {
+        self.get_entry(key).map(|e| e.0)
+    }
+
+    /// Determines if `key` is in the `Map`.
+    pub fn contains_key<T: ?Sized>(&self, key: &T) -> bool
+        where T: Eq + PhfHash,
+              K: Borrow<T>
+    {
+        self.get(key).is_some()
+    }
+
+    /// Returns the index of the key within the list used to initialize
+    /// the ordered map.
+    pub fn get_index<T: ?Sized>(&self, key: &T) -> Option<usize>
+        where T: Eq + PhfHash,
+              K: Borrow<T>
+    {
+        self.get_internal(key).map(|(i, _)| i)
+    }
+
+    /// Returns references to both the key and values at an index
+    /// within the list used to initialize the ordered map. See `.get_index(key)`.
+    pub fn index(&self, index: usize) -> Option<(&K, &V)> {
+        self.entries.get(index).map(|&(ref k, ref v)| (k, v))
+    }
+
+    /// Like `get`, but returns both the key and the value.
+    pub fn get_entry<T: ?Sized>(&self, key: &T) -> Option<(&K, &V)>
+        where T: Eq + PhfHash,
+              K: Borrow<T>
+    {
+        self.get_internal(key).map(|(_, e)| e)
+    }
+
+    fn get_internal<T: ?Sized>(&self, key: &T) -> Option<(usize, (&K, &V))>
+        where T: Eq + PhfHash,
+              K: Borrow<T>
+    {
+        if self.disps.len() == 0 { return None; } //Prevent panic on empty map
+        let hashes = phf_shared::hash(key, &self.key);
+        let idx_index = phf_shared::get_index(&hashes, &*self.disps, self.idxs.len());
+        let idx = self.idxs[idx_index as usize];
+        let entry = &self.entries[idx];
+
+        let b: &T = entry.0.borrow();
+        if b == key {
+            Some((idx, (&entry.0, &entry.1)))
+        } else {
+            None
+        }
+    }
+
+    /// Returns an iterator over the key/value pairs in the map.
+    ///
+    /// Entries are returned in the same order in which they were defined.
+    pub fn entries<'a>(&'a self) -> Entries<'a, K, V> {
+        Entries { iter: self.entries.iter() }
+    }
+
+    /// Returns an iterator over the keys in the map.
+    ///
+    /// Keys are returned in the same order in which they were defined.
+    pub fn keys<'a>(&'a self) -> Keys<'a, K, V> {
+        Keys { iter: self.entries() }
+    }
+
+    /// Returns an iterator over the values in the map.
+    ///
+    /// Values are returned in the same order in which they were defined.
+    pub fn values<'a>(&'a self) -> Values<'a, K, V> {
+        Values { iter: self.entries() }
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a OrderedMap<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = Entries<'a, K, V>;
+
+    fn into_iter(self) -> Entries<'a, K, V> {
+        self.entries()
+    }
+}
+
+/// An iterator over the entries in a `OrderedMap`.
+pub struct Entries<'a, K: 'a, V: 'a> {
+    iter: slice::Iter<'a, (K, V)>,
+}
+
+impl<'a, K, V> Iterator for Entries<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<(&'a K, &'a V)> {
+        self.iter.next().map(|e| (&e.0, &e.1))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a, K, V> DoubleEndedIterator for Entries<'a, K, V> {
+    fn next_back(&mut self) -> Option<(&'a K, &'a V)> {
+        self.iter.next_back().map(|e| (&e.0, &e.1))
+    }
+}
+
+impl<'a, K, V> ExactSizeIterator for Entries<'a, K, V> {}
+
+/// An iterator over the keys in a `OrderedMap`.
+pub struct Keys<'a, K: 'a, V: 'a> {
+    iter: Entries<'a, K, V>,
+}
+
+impl<'a, K, V> Iterator for Keys<'a, K, V> {
+    type Item = &'a K;
+
+    fn next(&mut self) -> Option<&'a K> {
+        self.iter.next().map(|e| e.0)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a, K, V> DoubleEndedIterator for Keys<'a, K, V> {
+    fn next_back(&mut self) -> Option<&'a K> {
+        self.iter.next_back().map(|e| e.0)
+    }
+}
+
+impl<'a, K, V> ExactSizeIterator for Keys<'a, K, V> {}
+
+/// An iterator over the values in a `OrderedMap`.
+pub struct Values<'a, K: 'a, V: 'a> {
+    iter: Entries<'a, K, V>,
+}
+
+impl<'a, K, V> Iterator for Values<'a, K, V> {
+    type Item = &'a V;
+
+    fn next(&mut self) -> Option<&'a V> {
+        self.iter.next().map(|e| e.1)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a, K, V> DoubleEndedIterator for Values<'a, K, V> {
+    fn next_back(&mut self) -> Option<&'a V> {
+        self.iter.next_back().map(|e| e.1)
+    }
+}
+
+impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {}

--- a/phf/src/ordered_set.rs
+++ b/phf/src/ordered_set.rs
@@ -1,0 +1,136 @@
+//! An order-preserving immutable set constructed at compile time.
+use core::borrow::Borrow;
+use core::iter::IntoIterator;
+use core::fmt;
+use crate::{ordered_map, PhfHash, OrderedMap};
+
+/// An order-preserving immutable set constructed at compile time.
+///
+/// Unlike a `Set`, iteration order is guaranteed to match the definition
+/// order.
+///
+/// ## Note
+///
+/// The fields of this struct are public so that they may be initialized by the
+/// `phf_ordered_set!` macro and code generation. They are subject to change at
+/// any time and should never be accessed directly.
+pub struct OrderedSet<T: 'static> {
+    #[doc(hidden)]
+    pub map: OrderedMap<T, ()>,
+}
+
+impl<T> fmt::Debug for OrderedSet<T> where T: fmt::Debug {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_set().entries(self).finish()
+    }
+}
+
+impl<T> OrderedSet<T> {
+    /// Returns the number of elements in the `OrderedSet`.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Returns true if the `OrderedSet` contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns a reference to the set's internal static instance of the given
+    /// key.
+    ///
+    /// This can be useful for interning schemes.
+    pub fn get_key<U: ?Sized>(&self, key: &U) -> Option<&T>
+        where U: Eq + PhfHash,
+              T: Borrow<U>
+    {
+        self.map.get_key(key)
+    }
+
+    /// Returns the index of the key within the list used to initialize
+    /// the ordered set.
+    pub fn get_index<U: ?Sized>(&self, key: &U) -> Option<usize>
+        where U: Eq + PhfHash,
+              T: Borrow<U>
+    {
+        self.map.get_index(key)
+    }
+
+    /// Returns a reference to the key at an index
+    /// within the list used to initialize the ordered set. See `.get_index(key)`.
+    pub fn index(&self, index: usize) -> Option<&T> {
+        self.map.index(index).map(|(k, &())| k)
+    }
+
+    /// Returns true if `value` is in the `Set`.
+    pub fn contains<U: ?Sized>(&self, value: &U) -> bool
+        where U: Eq + PhfHash,
+              T: Borrow<U>
+    {
+        self.map.contains_key(value)
+    }
+
+    /// Returns an iterator over the values in the set.
+    ///
+    /// Values are returned in the same order in which they were defined.
+    pub fn iter<'a>(&'a self) -> Iter<'a, T> {
+        Iter { iter: self.map.keys() }
+    }
+}
+
+impl<T> OrderedSet<T> where T: Eq + PhfHash {
+    /// Returns true if `other` shares no elements with `self`.
+    #[inline]
+    pub fn is_disjoint(&self, other: &OrderedSet<T>) -> bool {
+        !self.iter().any(|value| other.contains(value))
+    }
+
+    /// Returns true if `other` contains all values in `self`.
+    #[inline]
+    pub fn is_subset(&self, other: &OrderedSet<T>) -> bool {
+        self.iter().all(|value| other.contains(value))
+    }
+
+    /// Returns true if `self` contains all values in `other`.
+    #[inline]
+    pub fn is_superset(&self, other: &OrderedSet<T>) -> bool {
+        other.is_subset(self)
+    }
+}
+
+impl<'a, T> IntoIterator for &'a OrderedSet<T> {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Iter<'a, T> {
+        self.iter()
+    }
+}
+
+/// An iterator over the values in a `OrderedSet`.
+pub struct Iter<'a, T: 'a> {
+    iter: ordered_map::Keys<'a, T, ()>,
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    #[inline]
+    fn next(&mut self) -> Option<&'a T> {
+        self.iter.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
+    #[inline]
+    fn next_back(&mut self) -> Option<&'a T> {
+        self.iter.next_back()
+    }
+}
+
+impl<'a, T> ExactSizeIterator for Iter<'a, T> {}

--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -34,6 +34,26 @@ fn main() -> io::Result<()> {
 
     writeln!(
         &mut file,
+        "static ORDERED_MAP: ::phf::OrderedMap<u32, &'static str> = \n{};",
+        phf_codegen::OrderedMap::new()
+            .entry(1u32, "\"a\"")
+            .entry(2u32, "\"b\"")
+            .entry(3u32, "\"c\"")
+            .build()
+    )?;
+
+    writeln!(
+        &mut file,
+        "static ORDERED_SET: ::phf::OrderedSet<u32> = \n{};",
+        phf_codegen::OrderedSet::new()
+            .entry(1u32)
+            .entry(2u32)
+            .entry(3u32)
+            .build()
+    )?;
+
+    writeln!(
+        &mut file,
         "static STR_KEYS: ::phf::Map<&'static str, u32> = \n{};",
         phf_codegen::Map::new()
             .entry("a", "1")
@@ -55,6 +75,10 @@ fn main() -> io::Result<()> {
     writeln!(&mut file,
              "static EMPTY: ::phf::Map<u32, u32> = \n{};",
              phf_codegen::Map::<u32>::new().build())?;
+
+    writeln!(&mut file,
+             "static EMPTY_ORDERED: ::phf::OrderedMap<u32, u32> = \n{};",
+             phf_codegen::OrderedMap::<u32>::new().build())?;
 
     writeln!(&mut file, "static ARRAY_KEYS: ::phf::Map<[u8; 3], u32> = \n{};",
              phf_codegen::Map::<[u8; 3]>::new()

--- a/phf_codegen/test/src/lib.rs
+++ b/phf_codegen/test/src/lib.rs
@@ -21,6 +21,24 @@ mod test {
     }
 
     #[test]
+    fn ordered_map() {
+        assert_eq!("a", ORDERED_MAP[&1]);
+        assert_eq!("b", ORDERED_MAP[&2]);
+        assert_eq!("c", ORDERED_MAP[&3]);
+        assert!(!ORDERED_MAP.contains_key(&100));
+        assert_eq!(&["a", "b", "c"][..], &ORDERED_MAP.values().cloned().collect::<Vec<_>>()[..]);
+    }
+
+    #[test]
+    fn ordered_set() {
+        assert!(ORDERED_SET.contains(&1));
+        assert!(ORDERED_SET.contains(&2));
+        assert!(ORDERED_SET.contains(&3));
+        assert!(!ORDERED_SET.contains(&4));
+        assert_eq!(&[1, 2, 3][..], &ORDERED_SET.iter().cloned().collect::<Vec<_>>()[..]);
+    }
+
+    #[test]
     fn str_keys() {
         assert_eq!(1, STR_KEYS["a"]);
         assert_eq!(2, STR_KEYS["b"]);
@@ -55,4 +73,11 @@ mod test {
     fn empty_map() {
         assert_eq!(None, EMPTY.get(&1));
     }
+
+     #[test]
+    fn empty_ordered_map() {
+        assert_eq!(None, EMPTY_ORDERED.get(&1));
+    }
+
+
 }

--- a/phf_macros/tests/test.rs
+++ b/phf_macros/tests/test.rs
@@ -309,3 +309,212 @@ mod set {
         }
     }
 }
+
+mod ordered_map {
+    use phf::phf_ordered_map;
+
+    #[allow(dead_code)]
+    static TRAILING_COMMA: phf::OrderedMap<&'static str, isize> = phf_ordered_map!(
+        "foo" => 10,
+    );
+
+    #[allow(dead_code)]
+    static NO_TRAILING_COMMA: phf::OrderedMap<&'static str, isize> = phf_ordered_map!(
+        "foo" => 10
+    );
+
+    #[test]
+    fn test_two() {
+        static MAP: phf::OrderedMap<&'static str, isize> = phf_ordered_map!(
+            "foo" => 10,
+            "bar" => 11,
+        );
+        assert!(Some(&10) == MAP.get(&"foo"));
+        assert!(Some(&11) == MAP.get(&"bar"));
+        assert_eq!(None, MAP.get(&"asdf"));
+        assert_eq!(2, MAP.len());
+    }
+
+    #[test]
+    fn test_get_index() {
+        static MAP: phf::OrderedMap<&'static str, isize> = phf_ordered_map!(
+            "foo" => 5,
+            "bar" => 5,
+            "baz" => 5,
+        );
+        assert_eq!(Some(0), MAP.get_index(&"foo"));
+        assert_eq!(Some(2), MAP.get_index(&"baz"));
+        assert_eq!(None, MAP.get_index(&"xyz"));
+
+        assert_eq!(Some(0), MAP.get_index(&*"foo".to_string()));
+        assert_eq!(Some(2), MAP.get_index(&*"baz".to_string()));
+        assert_eq!(None, MAP.get_index(&*"xyz".to_string()));
+    }
+
+    #[test]
+    fn test_index() {
+        static MAP: phf::OrderedMap<&'static str, isize> = phf_ordered_map!(
+            "foo" => 5,
+            "bar" => 6,
+        );
+        assert_eq!(Some((&"foo", &5)), MAP.index(0));
+        assert_eq!(Some((&"bar", &6)), MAP.index(1));
+        assert_eq!(None, MAP.index(2));
+    }
+
+    #[test]
+    fn test_entries() {
+        static MAP: phf::OrderedMap<&'static str, i32> = phf_ordered_map!(
+            "foo" => 10,
+            "bar" => 11,
+            "baz" => 12,
+        );
+        let vec = MAP.entries().map(|(&k, &v)| (k, v)).collect::<Vec<_>>();
+        assert_eq!(vec, vec!(("foo", 10), ("bar", 11), ("baz", 12)));
+    }
+
+    #[test]
+    fn test_keys() {
+        static MAP: phf::OrderedMap<&'static str, isize> = phf_ordered_map!(
+            "foo" => 10,
+            "bar" => 11,
+            "baz" => 12,
+        );
+        let vec = MAP.keys().map(|&e| e).collect::<Vec<_>>();
+        assert_eq!(vec, vec!("foo", "bar", "baz"));
+    }
+
+    #[test]
+    fn test_values() {
+        static MAP: phf::OrderedMap<&'static str, i32> = phf_ordered_map!(
+            "foo" => 10,
+            "bar" => 11,
+            "baz" => 12,
+        );
+        let vec = MAP.values().map(|&v| v).collect::<Vec<_>>();
+        assert_eq!(vec, vec!(10, 11, 12));
+    }
+
+    #[test]
+    fn test_index_ok() {
+        static MAP: phf::OrderedMap<&'static str, isize> = phf_ordered_map!(
+            "a" => 0,
+        );
+        assert_eq!(0, MAP["a"]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_index_fail() {
+        static MAP: phf::OrderedMap<&'static str, isize> = phf_ordered_map!(
+            "a" => 0,
+        );
+        MAP["b"];
+    }
+
+    #[test]
+    fn test_non_static_str_key() {
+        static MAP: phf::OrderedMap<&'static str, isize> = phf_ordered_map!(
+            "a" => 0,
+        );
+        assert_eq!(Some(&0), MAP.get(&*"a".to_string()));
+    }
+
+    #[test]
+    fn test_into_iterator() {
+        static MAP: phf::OrderedMap<&'static str, isize> = phf_ordered_map!(
+            "foo" => 10,
+        );
+
+        for (k, v) in &MAP {
+            assert_eq!(&"foo", k);
+            assert_eq!(&10, v)
+        }
+    }
+}
+
+mod ordered_set {
+    use phf::phf_ordered_set;
+
+    #[allow(dead_code)]
+    static TRAILING_COMMA: phf::OrderedSet<&'static str> = phf_ordered_set! {
+        "foo",
+    };
+
+    #[allow(dead_code)]
+    static NO_TRAILING_COMMA: phf::OrderedSet<&'static str> = phf_ordered_set! {
+        "foo"
+    };
+
+    #[test]
+    fn test_two() {
+        static SET: phf::OrderedSet<&'static str> = phf_ordered_set! {
+            "hello",
+            "there",
+            "world",
+        };
+        assert!(SET.contains(&"hello"));
+        assert!(SET.contains(&"there"));
+        assert!(SET.contains(&"world"));
+        assert!(!SET.contains(&"foo"));
+        assert_eq!(3, SET.len());
+    }
+
+    #[test]
+    fn test_get_index() {
+        static SET: phf::OrderedSet<&'static str> = phf_ordered_set! {
+            "foo",
+            "bar",
+            "baz",
+        };
+        assert_eq!(Some(0), SET.get_index(&"foo"));
+        assert_eq!(Some(2), SET.get_index(&"baz"));
+        assert_eq!(None, SET.get_index(&"xyz"));
+
+        assert_eq!(Some(0), SET.get_index(&*"foo".to_string()));
+        assert_eq!(Some(2), SET.get_index(&*"baz".to_string()));
+        assert_eq!(None, SET.get_index(&*"xyz".to_string()));
+    }
+
+    #[test]
+    fn test_index() {
+        static MAP: phf::OrderedSet<&'static str> = phf_ordered_set!(
+            "foo",
+            "bar",
+        );
+        assert_eq!(Some(&"foo"), MAP.index(0));
+        assert_eq!(Some(&"bar"), MAP.index(1));
+        assert_eq!(None, MAP.index(2));
+    }
+
+    #[test]
+    fn test_iter() {
+        static SET: phf::OrderedSet<&'static str> = phf_ordered_set! {
+            "hello",
+            "there",
+            "world",
+        };
+        let vec = SET.iter().map(|&e| e).collect::<Vec<_>>();
+        assert_eq!(vec, vec!("hello", "there", "world"));
+    }
+
+    #[test]
+    fn test_non_static_str_contains() {
+        static SET: phf::OrderedSet<&'static str> = phf_ordered_set! {
+            "hello",
+            "world",
+        };
+        assert!(SET.contains(&*"hello".to_string()));
+    }
+
+    #[test]
+    fn test_into_iterator() {
+        static SET: phf::OrderedSet<&'static str> = phf_ordered_set!(
+            "foo",
+        );
+
+        for e in &SET {
+            assert_eq!(&"foo", e);
+        }
+    }
+}


### PR DESCRIPTION
Ordered maps and sets were removed in #171 for being unused, but people have come out who need them (see comments in #170). So I added them back.