### PR TITLE
Fix `phf_macros` on `no_std`

### DIFF
--- a/phf_generator/Cargo.toml
+++ b/phf_generator/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 rand = { version = "0.8", features = ["small_rng"] }
-phf_shared = { version = "0.8.0", path = "../phf_shared" }
+phf_shared = { version = "0.8.0", path = "../phf_shared", default-features = false }
 # for stable black_box()
 criterion = { version = "0.3", optional = true }
 

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro2 = "1"
 proc-macro-hack = "0.5.4"
 
 phf_generator = { version = "0.8.0", path = "../phf_generator" }
-phf_shared = { version = "0.8.0", path = "../phf_shared" }
+phf_shared = { version = "0.8.0", path = "../phf_shared", default-features = false }
 
 [dev-dependencies]
 trybuild = "1.0"


### PR DESCRIPTION
Currently, `phf` does not compile on `no_std` with `features = ["macros"]` enabled. This PR tries to fix this by adding `default-features = false` to `phf_generator/Cargo.toml` and `phf_macros/Cargo.toml`.

Tested on [my own project](https://github.com/new-tee-os/new-tee-os/blob/3dbc06e45c2f20540e0c3e69e54d1b161ace0e48/linux-abi/Cargo.toml#L15) and seemed to be working.