### PR TITLE
Bump MSRV to 1.40.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ save_registry: &SAVE_REGISTRY
   save_cache:
     key: registry-{{ .BuildNum }}
     paths:
-    - /usr/local/cargo/registry/index
+      - /usr/local/cargo/registry/index
 deps_key: &DEPS_KEY
   key: deps-{{ checksum "~/rust-version" }}-{{ checksum "Cargo.lock" }}
 restore_deps: &RESTORE_DEPS
@@ -15,14 +15,14 @@ save_deps: &SAVE_DEPS
   save_cache:
     <<: *DEPS_KEY
     paths:
-    - target
-    - /usr/local/cargo/registry/cache
+      - target
+      - /usr/local/cargo/registry/cache
 
 version: 2
 jobs:
   stable:
     docker:
-      - image: rust:1.36.0-slim
+      - image: rust:1.40.0-slim
     environment:
       RUSTFLAGS: -D warnings
     steps:

--- a/phf_macros/tests/compile-fail-unicase/equivalent-keys.stderr
+++ b/phf_macros/tests/compile-fail-unicase/equivalent-keys.stderr
@@ -4,4 +4,4 @@ error: unsupported key expression
 5 |     UniCase("FOO") => 42, //~ NOTE one occurrence here
   |     ^^^^^^^^^^^^^^
   |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `proc_macro_call` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/phf_macros/tests/compile-fail/bad-syntax.stderr
+++ b/phf_macros/tests/compile-fail/bad-syntax.stderr
@@ -4,4 +4,4 @@ error: expected identifier
 5 |     => //~ ERROR expected identifier
   |     ^^
   |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `proc_macro_call` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Our dependency uses memchr 2.4.0 which uses an unstable feature on 1.36.0. While we updated our MSRV in #201, I don't think it's a matter to update it to 1.40.0.