### PR TITLE
Replace `std::borrow::Borrow` with `PhfBorrow` for ordered maps and sets

### DIFF
--- a/phf/src/ordered_set.rs
+++ b/phf/src/ordered_set.rs
@@ -1,7 +1,7 @@
 //! An order-preserving immutable set constructed at compile time.
-use core::borrow::Borrow;
 use core::iter::IntoIterator;
 use core::fmt;
+use phf_shared::PhfBorrow;
 use crate::{ordered_map, PhfHash, OrderedMap};
 
 /// An order-preserving immutable set constructed at compile time.
@@ -42,7 +42,7 @@ impl<T> OrderedSet<T> {
     /// This can be useful for interning schemes.
     pub fn get_key<U: ?Sized>(&self, key: &U) -> Option<&T>
         where U: Eq + PhfHash,
-              T: Borrow<U>
+              T: PhfBorrow<U>
     {
         self.map.get_key(key)
     }
@@ -51,7 +51,7 @@ impl<T> OrderedSet<T> {
     /// the ordered set.
     pub fn get_index<U: ?Sized>(&self, key: &U) -> Option<usize>
         where U: Eq + PhfHash,
-              T: Borrow<U>
+              T: PhfBorrow<U>
     {
         self.map.get_index(key)
     }
@@ -65,7 +65,7 @@ impl<T> OrderedSet<T> {
     /// Returns true if `value` is in the `Set`.
     pub fn contains<U: ?Sized>(&self, value: &U) -> bool
         where U: Eq + PhfHash,
-              T: Borrow<U>
+              T: PhfBorrow<U>
     {
         self.map.contains_key(value)
     }
@@ -78,7 +78,7 @@ impl<T> OrderedSet<T> {
     }
 }
 
-impl<T> OrderedSet<T> where T: Eq + PhfHash {
+impl<T> OrderedSet<T> where T: Eq + PhfHash + PhfBorrow<T> {
     /// Returns true if `other` shares no elements with `self`.
     #[inline]
     pub fn is_disjoint(&self, other: &OrderedSet<T>) -> bool {


### PR DESCRIPTION
This probably makes sense, as this was just done to the other types.